### PR TITLE
Upgrade all Node job containers to `node:16-alpine`

### DIFF
--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:16-alpine
     continue-on-error: false
     outputs: 
       docs: ${{ steps.docs.outputs.present }}

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -139,7 +139,7 @@ jobs:
   build-artifact:
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:16-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       artifact-id: ${{ steps.build.outputs.artifact-id }}

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -160,7 +160,7 @@ jobs:
     if: ${{ !failure() }}
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:16-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
     env:

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -45,7 +45,7 @@ jobs:
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       version: ${{ steps.build.outputs.version }}
-    container: node:14-alpine
+    container: node:16-alpine
     steps:
     - name: Install Dependencies
       run: |

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:16-alpine
     continue-on-error: false
     outputs: 
       docs: ${{ steps.docs.outputs.present }}

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -77,7 +77,7 @@ jobs:
   build-artifact:
     needs: release-checks
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:16-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       artifact-id: ${{ steps.build.outputs.artifact-id }}

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       version: ${{ steps.build.outputs.version }}
-    container: node:14-alpine
+    container: node:16-alpine
     steps:
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
# Description

Some `container: ` properties on jobs were still using node v14. Based on [this search of the Zepben org](https://github.com/search?q=org%3Azepben+path%3Apackage.json+engine+OR+volta&type=code), all our repos require at least node v16.

This became a problem in https://github.com/zepben/ednar-web-client/pull/313, where the `npm ci` command [failed to install dependencies](https://github.com/zepben/ednar-web-client/actions/runs/7001189759/job/19042924046?pr=313#step:10:10) after the addition of `Playwright`.

After looking this issue up online, I found [this Stack Overflow post](https://stackoverflow.com/a/69121224) that mentioned similar issues if the `package-lock.json` file was v2 while `npm` was <v7. This is indeed the case when running `node` v14, where we get `npm `v6 (see docs [here](https://nodejs.org/en/download/releases#looking-for-latest-release-of-a-version-branch)).

## Testing

I believe this PR should be safe to merge and "Just Work ™" because all our repos require node v16 anyway. As such I haven't tested every repo's CI. If CI starts failing somewhere I'm happy to revert this change while we investigate.

# Associated tasks

Unblocks https://github.com/zepben/ednar-web-client/pull/313.

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] ~I have updated the changelog.~
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] ~I have considered if this is a breaking change and will communicate it with other team members if so.~