### PR TITLE
Disable husky for CI

### DIFF
--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -206,6 +206,8 @@ jobs:
 
       - name: build
         id: build
+        env:
+          HUSKY: 0
         run: |
           echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
           npm ci --unsafe-perm


### PR DESCRIPTION
# Description

This change will set an environment variable `HUSKY` to 0 during the ci run to disable pre-commit hooks via husky. At this stage, CI doesn't require these hooks to run.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
~- [ ] I have rebased onto the target branch (usually main).~
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.