### PR TITLE
Docs building and deployments updates

### DIFF
--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -27,6 +27,14 @@ on:
         required: false
         type: string
         default: "src"
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
       configuration:
         description: 'Configuration'
         required: false
@@ -57,6 +65,8 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: windows-2019
+    outputs:
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -93,9 +103,9 @@ jobs:
         new_info_version_date=$(date '+%d%m%Y%H%M%S')
         sed -i "s|$info_version_date|$new_info_version_date|g" ${{ inputs.version_file }}
         info_version=$(cat ${{ inputs.version_file }} | grep "AssemblyInformationalVersion(\"[0-9]\+\.[0-9]\+\.[0-9]\+.*\")" | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\++build[0-9]\+")
-        echo "info_version=$info_version" >> $GITHUB_OUTPUT
+        echo "info_version=$info_version" >> ${GITHUB_ENV}
         artifact_id=$(cat ${{ inputs.version_file }} | grep "AssemblyTitle" | egrep -o "\"[A-Za-z0-9\-]+\"" | tr -d '"')
-        echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
+        echo "artifact_id=$artifact_id" >> ${GITHUB_ENV}
 
     - name: Add ZepBen Nuget Repo credentials
       run: nuget sources update -Name "ZepBen" -username "${{ secrets.NEXUS_USERNAME }}" -password "${{ secrets.NEXUS_PASSWORD }}" -configFile "Nuget.Config"
@@ -127,5 +137,105 @@ jobs:
       id: upload
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ steps.update-info-version.outputs.artifact_id }}-${{ steps.update-info-version.outputs.info_version }}
-        path: ${{ steps.upload_path.outputs.path }}
+        name: ${{ env.artifact_id }}-${{ env.info_version }}
+        path: ${{ env.artifact_id }}/bin/Release/
+
+    - name: Check if docs present
+      id: docs
+      run: |
+        if [ -d docs ]; then
+          echo "Docs folder found, will run the build-docs job"
+          echo "present=yes" >> "${GITHUB_OUTPUT}"
+          echo "present=yes" >> "${GITHUB_ENV}"
+        else
+          echo "Docs folder not found, will skip the build-docs"
+        fi
+
+    - name: Work around git permission issue
+      run: |
+        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+        git config --global --add safe.directory /__w/$dname/$dname
+      shell: sh
+
+    - name: Check doc build artifacts are ignored
+      if: ${{ env.present == 'yes' }}
+      shell: sh {0}
+      run: |
+        # Make sure directories are properly ignored
+        # docs/node_modules
+        git check-ignore -q docs/node_modules 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            exit 1
+        fi
+
+        # docs/build
+        git check-ignore -q docs/build 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+            exit 1
+        fi
+
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: [build-app]
+    if: ${{ needs.build-app.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.build.outcome == 'success'
+        id: upload
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -47,7 +47,7 @@ jobs:
   build-and-test:
     runs-on: windows-2019
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
       DEBUG: ${{ secrets.DEBUG }}
@@ -102,15 +102,43 @@ jobs:
         if [ -d docs ]; then
           echo "Docs folder found, will run the build-docs job"
           echo "present=yes" >> "${GITHUB_OUTPUT}"
+          echo "present=yes" >> "${GITHUB_ENV}"
         else
           echo "Docs folder not found, will skip the build-docs"
+        fi
+
+    - name: Work around git permission issue
+      run: |
+        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+        git config --global --add safe.directory /__w/$dname/$dname
+      shell: sh
+
+    - name: Check doc build artifacts are ignored
+      if: ${{ env.present == 'yes' }}
+      shell: sh {0}
+      run: |
+        # Make sure directories are properly ignored
+        # docs/node_modules
+        git check-ignore -q docs/node_modules 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            exit 1
+        fi
+
+        # docs/build
+        git check-ignore -q docs/build 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/docs' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+            exit 1
         fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -119,6 +147,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -18,6 +18,14 @@ on:
         required: false
         type: string
         default: "src"
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -47,9 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java
     outputs:
-      check_container_config: ${{ steps.check_container_config.outputs.files_exists }}
-      artifact_name: ${{ steps.build.outputs.version }}
-      artifact_path: ${{ steps.build.outputs.artifact-path }}
+      docs-present: ${{ steps.docs.outputs.present }}
 
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
@@ -87,9 +93,9 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}.jar"
-          echo "::set-output name=version::$(echo $version)"
-          echo "::set-output name=artifactId::$(echo $artifactId)"
-          echo "::set-output name=artifact-path::$(echo target/$artifact)"
+          echo "version=$(echo $version)" >> ${GITHUB_ENV}
+          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo target/$artifact)" >> ${GITHUB_ENV}
           mvn clean package -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
 
       - name: Upload coverage to Codecov
@@ -100,8 +106,95 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.build.outputs.artifactId }}-${{ steps.build.outputs.version }}
-          path: ${{ steps.build.outputs.artifact-path }}
+          name: ${{ env.artifactId }}-${{ env.version }}
+          path: ${{ env.artifact-path }}
+
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: [build-app]
+    if: ${{ needs.build-app.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.build.outcome == 'success'
+        id: upload
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
 
   update-snapshot-version:
     needs: [build-app]
@@ -129,3 +222,17 @@ jobs:
       - name: Update snapshot version
         run: |
           /scripts/update-version.sh --java --snapshot --maven pom.xml
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'
+

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
 
@@ -45,15 +45,43 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -62,6 +90,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
@@ -81,15 +81,43 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -98,6 +126,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/maven-lib-snapshot.yml
+++ b/.github/workflows/maven-lib-snapshot.yml
@@ -18,6 +18,14 @@ on:
         required: false
         type: string
         default: "src"
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -49,6 +57,52 @@ on:
         required: false
 
 jobs:
+
+  check-docs:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-present: ${{ steps.docs.outputs.present }}
+    steps: 
+      - uses: actions/checkout@v3
+
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
   deploy:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java
@@ -77,16 +131,15 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
-
       - name: Set profile
         id: profile
         run: |
           priv=${{ inputs.private }}
           if [[ $priv == 'true' ]]
           then 
-            echo "::set-output name=profile::zepben-maven"; 
+            echo "PROFILE=zepben-maven" >> ${GITHUB_ENV} 
           else 
-            echo "::set-output name=profile::ossrh"
+            echo "PROFILE=ossrh" >> ${GITHUB_ENV}
           fi
 
       - name: Maven deploy to Central
@@ -102,11 +155,60 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_KEY_PASSWORD: ${{ secrets.GPG_KEY_PASSWORD }}
-          PROFILE: ${{ steps.profile.outputs.profile }}
+          PROFILE: ${{ env.PROFILE }}
 
       - name: Upload coverage to Codecov
         if: steps.build.outcome == 'success'
         uses: codecov/codecov-action@v2
+
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: [check-docs]
+    if: ${{ needs.check-docs.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.build.outcome == 'success'
+        id: upload
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
 
   update-snapshot-version:
     needs: [deploy]
@@ -134,3 +236,17 @@ jobs:
       - name: Update snapshot version
         run: |
           /scripts/update-version.sh --java --snapshot --maven pom.xml
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'
+

--- a/.github/workflows/maven-lib-snapshot.yml
+++ b/.github/workflows/maven-lib-snapshot.yml
@@ -65,6 +65,10 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
 
+      - name: Check inputs
+        run: |
+         echo "product repo is ${{ inputs.product-repo }}"
+
       - name: Check if docs present
         id: docs
         run: |

--- a/.github/workflows/maven-lib-snapshot.yml
+++ b/.github/workflows/maven-lib-snapshot.yml
@@ -65,10 +65,6 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
 
-      - name: Check inputs
-        run: |
-         echo "product repo is ${{ inputs.product-repo }}"
-
       - name: Check if docs present
         id: docs
         run: |

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -41,7 +41,7 @@ jobs:
     container: node:16-alpine
     continue-on-error: false
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - name: Install Dependencies
         run: |
@@ -93,15 +93,43 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -110,6 +138,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -8,11 +8,6 @@ on:
         required: false
         type: boolean
         default: true
-      build-docs:
-        description: 'Repo has docusaurus docs'
-        required: false
-        type: boolean
-        default: false
       licencecheck:
         description: 'Need to check licence headers/files'
         required: false
@@ -23,6 +18,14 @@ on:
         required: false
         type: string
         default: "src"
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
     secrets:
       NEXUS_NPM_REPO:
         required: true
@@ -43,9 +46,8 @@ jobs:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
     outputs:
-      artifact: ${{ steps.build.outputs.artifact }}
-      version: ${{ steps.build.outputs.version }}
-    container: node:16-alpine
+      docs-present: ${{ steps.docs.outputs.present }}
+    container: node:14-alpine
     steps:
     - name: Install Dependencies
       run: |
@@ -91,59 +93,107 @@ jobs:
         echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
         npm ci --unsafe-perm
         npm run prod
-        version=$(jq -r .version package.json)
+        # version=$(jq -r .version package.json)
         artifactId=$(jq -r .name package.json)
         artifact="$artifactId-$version-SNAPSHOT.tar.bz2"
         tar jcvf "$artifact" -C dist .
-        echo "version=$version" >> $GITHUB_OUTPUT
-        echo "artifact=$artifact" >> $GITHUB_OUTPUT
+        echo "artifact=$artifact" >> ${GITHUB_ENV}
 
     - uses: actions/upload-artifact@v3
       if: steps.build.outcome == 'success'
       with:
-          name: ${{ steps.build.outputs.artifact }}
-          path: ${{ steps.build.outputs.artifact }}
+          name: ${{ env.artifact }}
+          path: ${{ env.artifact }}
+
+    - name: Check if docs present
+      id: docs
+      run: |
+        if [ -d docs ]; then
+          echo "Docs folder found, will run the build-docs job"
+          echo "present=yes" >> "${GITHUB_OUTPUT}"
+          echo "present=yes" >> "${GITHUB_ENV}"
+        else
+          echo "Docs folder not found, will skip the build-docs"
+        fi
+
+    - name: Work around git permission issue
+      run: |
+        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+        git config --global --add safe.directory /__w/$dname/$dname
+      shell: sh
+
+    - name: Check doc build artifacts are ignored
+      if: ${{ env.present == 'yes' }}
+      shell: sh {0}
+      run: |
+        # Make sure directories are properly ignored
+        # docs/node_modules
+        git check-ignore -q docs/node_modules 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            exit 1
+        fi
+
+        # docs/build
+        git check-ignore -q docs/build 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+            exit 1
+        fi
 
   build-docs:
     runs-on: ubuntu-latest
-    if: ${{ inputs.build-docs }}
-    container: node:16-alpine
+    needs: [build-artifact]
+    if: ${{ needs.build-artifact.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
     steps:
-      - name: Install Dependencies
-        run: |
-          apk add tar 
-
-      - name: Cache nodejs deps
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm
-
       - uses: actions/checkout@v3
 
-      - name: create .npmrc
-        run: | 
-          rm -rf ~/.npmrc
-          echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> ~/.npmrc
-          echo "//mavenrepo.zepben.com/repository/zepben-npm/:_authToken=${{ secrets.CI_NPM_TOKEN }}" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.CI_GITHUB_TOKEN }}" >> ~/.npmrc
-          echo "\n" >> ~/.npmrc
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
 
-      - name: Build docs
-        id: docs
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
         run: |
-          cd docs
-          npm ci --unsafe-perm
-          npm run build
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
 
       - uses: actions/upload-artifact@v3
-        if: steps.docs.outcome == 'success' 
+        if: steps.build.outcome == 'success'
+        id: upload
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
 
   update-snapshot-version:
-    needs: [build-artifact, build-docs]
+    needs: [build-artifact]
     container: zepben/pipeline-basic
     runs-on: ubuntu-latest
     env:
@@ -165,3 +215,17 @@ jobs:
       - name: Update snapshot version
         run: |
           /scripts/update-version.sh --js --snapshot package.json
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'
+

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
     container: node:16-alpine
     continue-on-error: false
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - name: Install Dependencies
         run: |
@@ -87,15 +87,43 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -104,6 +132,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -1,4 +1,4 @@
-name: NPM Static App Snapshot Release
+name: NPM Static Lib Snapshot Release
 
 on:
   workflow_call:
@@ -18,6 +18,14 @@ on:
         required: false
         type: string
         default: "src"
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
     secrets:
       NEXUS_NPM_REPO:
         required: true
@@ -37,10 +45,9 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
+    container: node:14-alpine
     outputs:
-      artifact: ${{ steps.build.outputs.artifact }}
-      version: ${{ steps.build.outputs.version }}
-    container: node:16-alpine
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
     - name: Install Dependencies
       run: |
@@ -87,15 +94,101 @@ jobs:
         npm run build
         artifact=$(npm pack)
         npm publish
-        version=$(jq -r .version package.json)
-        echo "::set-output name=version::$(echo $version)"
-        echo "::set-output name=artifact::$(echo $artifact)"
+        # version=$(jq -r .version package.json)
+        echo "artifact=$(echo $artifact)" >> ${GITHUB_ENV}
 
     - uses: actions/upload-artifact@v3
       if: steps.build.outcome == 'success'
       with:
-          name: ${{ steps.build.outputs.artifact }}
-          path: ${{ steps.build.outputs.artifact }}
+          name: ${{ env.artifact }}
+          path: ${{ env.artifact }}
+
+    - name: Check if docs present
+      id: docs
+      run: |
+        if [ -d docs ]; then
+          echo "Docs folder found, will run the build-docs job"
+          echo "present=yes" >> "${GITHUB_OUTPUT}"
+          echo "present=yes" >> "${GITHUB_ENV}"
+        else
+          echo "Docs folder not found, will skip the build-docs"
+        fi
+
+    - name: Work around git permission issue
+      run: |
+        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+        git config --global --add safe.directory /__w/$dname/$dname
+      shell: sh
+
+    - name: Check doc build artifacts are ignored
+      if: ${{ env.present == 'yes' }}
+      shell: sh {0}
+      run: |
+        # Make sure directories are properly ignored
+        # docs/node_modules
+        git check-ignore -q docs/node_modules 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+            exit 1
+        fi
+
+        # docs/build
+        git check-ignore -q docs/build 
+        if [ $? != 0 ]; then
+            echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+            exit 1
+        fi
+
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: [build-artifact]
+    if: ${{ needs.build-artifact.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.build.outcome == 'success'
+        id: upload
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
 
   update-snapshot-version:
     needs: [build-artifact]
@@ -120,3 +213,17 @@ jobs:
       - name: Update snapshot version
         run: |
           /scripts/update-version.sh --js --snapshot package.json
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'
+

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.9
     outputs: 
-      docs: ${{ steps.docs.outputs.present }}
+      docs-present: ${{ steps.docs.outputs.present }}
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     steps:
@@ -67,15 +67,43 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs == 'yes' }}
-    container: node:16-alpine
+    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    container: node:20-alpine
     steps:
 
       - uses: actions/checkout@v3
@@ -84,6 +112,6 @@ jobs:
         id: build
         uses: zepben/docusaurus-action@main
         with:
-          TAG-AND-RELEASE: false
+          TAG: false
           NPM_REPO: ${{ secrets.NPM_REPO }}
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/python-lib-snapshot.yml
+++ b/.github/workflows/python-lib-snapshot.yml
@@ -127,8 +127,8 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    needs: [build-app]
-    if: ${{ needs.build-app.outputs.docs-present == 'yes' }}
+    needs: [deploy]
+    if: ${{ needs.deploy.outputs.docs-present == 'yes' }}
     outputs:
       artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
     steps:

--- a/.github/workflows/python-lib-snapshot.yml
+++ b/.github/workflows/python-lib-snapshot.yml
@@ -2,6 +2,15 @@ name: Python Library Snapshot
 
 on:
   workflow_call:
+    inputs:
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: true
+        type: string
+      product-repo:
+        description: 'Product repository used for downloading snapshot docs'
+        required: true
+        type: string
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -18,6 +27,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     container: python:3.9
+    outputs:
+      docs-present: ${{ steps.docs.outputs.present }}
 
     steps:
       - uses: actions/checkout@v3
@@ -53,6 +64,44 @@ jobs:
         with:
           fail_ci_if_error: false
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
   update-snapshot-version:
     needs: [deploy]
     container: zepben/pipeline-basic
@@ -75,3 +124,66 @@ jobs:
         run: |
           /scripts/update-version.sh --python --snapshot setup.py
         shell: bash
+
+  build-docs:
+    runs-on: ubuntu-latest
+    needs: [build-app]
+    if: ${{ needs.build-app.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact-uploaded: ${{ steps.artifact.outputs.uploaded }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache-dependency-path: docs/package-lock.json
+          cache: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          TAG: false
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Failed build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "There was an error in the docusaurus build above. Docs are not pushed"
+          echo " :boom: There was an error in the docusaurus build step. Current docs are not published" >> ${GITHUB_STEP_SUMMARY}
+        shell: sh
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.build.outcome == 'success'
+        id: upload
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - if: steps.upload.outcome == 'success'
+        id: artifact
+        run:
+          echo "uploaded=yes" >> "${GITHUB_OUTPUT}"
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    if: ${{ needs.build-docs.outputs.artifact-uploaded == 'yes' }}
+    steps:
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "${{inputs.product-repo}}"}'
+

--- a/workflow-templates/csharp-app-snapshot.yml
+++ b/workflow-templates/csharp-app-snapshot.yml
@@ -8,6 +8,7 @@ jobs:
     uses: zepben/.github/.github/workflows/csharp-app-snapshot.yml@main
     with:
       test_files: data-access-layer-test\bin\Release\data-access-layer-test.dll
-      version_file: ednar-reporting-service/Properties/AssemblyInfo.cs
+      version_file: <some-path>/Properties/AssemblyInfo.cs
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit
     

--- a/workflow-templates/csharp-app-snapshot.yml
+++ b/workflow-templates/csharp-app-snapshot.yml
@@ -10,5 +10,6 @@ jobs:
       test_files: data-access-layer-test\bin\Release\data-access-layer-test.dll
       version_file: <some-path>/Properties/AssemblyInfo.cs
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>"
     secrets: inherit
     

--- a/workflow-templates/maven-app-snapshot.yml
+++ b/workflow-templates/maven-app-snapshot.yml
@@ -7,5 +7,6 @@ jobs:
     uses: zepben/.github/.github/workflows/maven-app-snapshot.yml@main
     with:
       private: true
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit
     

--- a/workflow-templates/maven-app-snapshot.yml
+++ b/workflow-templates/maven-app-snapshot.yml
@@ -8,5 +8,6 @@ jobs:
     with:
       private: true
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>" 
     secrets: inherit
     

--- a/workflow-templates/maven-lib-snapshot.yml
+++ b/workflow-templates/maven-lib-snapshot.yml
@@ -12,4 +12,5 @@ jobs:
     uses: zepben/.github/.github/workflows/maven-lib-snapshot.yml@main
     with:
       private: true
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit

--- a/workflow-templates/maven-lib-snapshot.yml
+++ b/workflow-templates/maven-lib-snapshot.yml
@@ -13,4 +13,5 @@ jobs:
     with:
       private: true
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>"
     secrets: inherit

--- a/workflow-templates/npm-app-snapshot-release.yml
+++ b/workflow-templates/npm-app-snapshot-release.yml
@@ -7,4 +7,5 @@ jobs:
     uses: zepben/.github/.github/workflows/npm-app-snapshot-release.yml@main
     with:
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>"
     secrets: inherit

--- a/workflow-templates/npm-app-snapshot-release.yml
+++ b/workflow-templates/npm-app-snapshot-release.yml
@@ -5,4 +5,6 @@ on: workflow_dispatch
 jobs:
   run:
     uses: zepben/.github/.github/workflows/npm-app-snapshot-release.yml@main
+    with:
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit

--- a/workflow-templates/npm-lib-snapshot-release.yml
+++ b/workflow-templates/npm-lib-snapshot-release.yml
@@ -11,4 +11,6 @@ on:
 jobs:
   run:
     uses: zepben/.github/.github/workflows/npm-lib-snapshot.yml@main
+    with:
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit

--- a/workflow-templates/npm-lib-snapshot-release.yml
+++ b/workflow-templates/npm-lib-snapshot-release.yml
@@ -13,4 +13,5 @@ jobs:
     uses: zepben/.github/.github/workflows/npm-lib-snapshot.yml@main
     with:
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>"
     secrets: inherit

--- a/workflow-templates/python-lib-snapshot.yml
+++ b/workflow-templates/python-lib-snapshot.yml
@@ -12,4 +12,5 @@ jobs:
     uses: zepben/.github/.github/workflows/python-lib-snapshot.yml@main
     with:
       product-key: "<some-product-key>"   # Must be unique
+      product-repo: "<some-product-repo>" 
     secrets: inherit

--- a/workflow-templates/python-lib-snapshot.yml
+++ b/workflow-templates/python-lib-snapshot.yml
@@ -10,4 +10,6 @@ on:
 jobs:
   run:
     uses: zepben/.github/.github/workflows/python-lib-snapshot.yml@main
+    with:
+      product-key: "<some-product-key>"   # Must be unique
     secrets: inherit


### PR DESCRIPTION
* Add docs building and deployment to all snapshot releases. It's done without tagging a new version; i.e. the deployment will update the "next" version only.
* Switch all docs building to node-20
* Update the old ways to output in GH actions with the new one ($GITHUB_OUTPUT)
* Cleanup unused code
* Replace TAG-AND-RELEASE flag to docs building with TAG.
* Update all templates with the product-key example.


# Associated tasks

https://github.com/zepben/docusaurus-action/pull/7

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~ [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.