### PR TITLE
Align node versions

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     steps:
       - name: Install Git
         run: |

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     steps:
       - name: Install Git
         run: |

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     steps:
       - name: Install Git
         run: |

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:20-alpine
     continue-on-error: false
     outputs: 
       docs-present: ${{ steps.docs.outputs.present }}

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
@@ -139,7 +139,7 @@ jobs:
   build-artifact:
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:20-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       artifact-id: ${{ steps.build.outputs.artifact-id }}

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
@@ -160,7 +160,7 @@ jobs:
     if: ${{ !failure() }}
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:20-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
     env:

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs-present: ${{ steps.docs.outputs.present }}
-    container: node:14-alpine
+    container: node:20-alpine
     steps:
     - name: Install Dependencies
       run: |

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:20-alpine
     continue-on-error: false
     outputs: 
       docs-present: ${{ steps.docs.outputs.present }}

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -77,7 +77,7 @@ jobs:
   build-artifact:
     needs: release-checks
     runs-on: ubuntu-latest
-    container: node:16-alpine
+    container: node:20-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
       artifact-id: ${{ steps.build.outputs.artifact-id }}

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       LICENCE_CHECK: ${{ inputs.licencecheck }}
     runs-on: ubuntu-latest
-    container: node:14-alpine
+    container: node:20-alpine
     outputs:
       docs-present: ${{ steps.docs.outputs.present }}
     steps:

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: docs
-    container: node:16-alpine
+    container: node:20-alpine
     steps:
       - name: Install Git
         run: |


### PR DESCRIPTION
# Description

Use node20 to build all node projects (docs and front-end). Some have been reverted to 14 by mistake due to possible merge conflicts; others are on 16 and some are on 20.

This aligns all of them.