### PR TITLE
Fixing the npm container to run the licencecheck; adding bash to it

### DIFF
--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add jq tar alpine-conf git openssh
+          apk add jq tar alpine-conf git openssh bash
 
       - name: Cache nodejs deps
         uses: actions/cache@v3

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        apk add jq tar alpine-conf git
+        apk add jq tar alpine-conf git bash
 
     - name: Cache nodejs deps
       uses: actions/cache@v3

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add jq tar alpine-conf git
+          apk add jq tar alpine-conf git bash
 
       - name: Cache nodejs deps
         uses: actions/cache@v3

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        apk add jq tar alpine-conf git
+        apk add jq tar alpine-conf git bash
 
     - name: Cache nodejs deps
       uses: actions/cache@v3


### PR DESCRIPTION
# Description

We've possibly never run the licensecheck for some of the npm projects, so didn't hit the issue before. Adding bash to node20 image as that's what licensecheck uses.


### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).