### PR TITLE
[OPS-195] Fail the npm-lib-release:upload-artifact step if no files were found to upload

### DIFF
--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact }}
+          if-no-files-found: error
 
       - name: Fail build
         if: steps.build.outcome == 'failure'


### PR DESCRIPTION
# Description

[Clickup task](https://app.clickup.com/t/86cv7hv8w).



# Associated tasks

None.

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] ~I have updated the changelog.~
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.
	- Technically this is a breaking change for the workflow, but I believe it's only positive. Failing faster is generally good.