### PR TITLE
[OPS-201] Fix mangled artifact name in npm-lib-snapshot/release workflows

### DIFF
--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -128,7 +128,10 @@ jobs:
           echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
           npm ci --unsafe-perm
           npm run build
-          artifact=$(npm pack)
+          # We run npm pack twice because the command may log extra stdout from the `prepare` script.
+          # We want all logs in CI, but we also want to capture just the artifact name.
+          npm pack
+          artifact="$(npm pack --foreground-scripts=false --json --dry-run | jq -r .[0].filename)"
           npm publish
           version=$(jq -r .version package.json)
           echo "::set-output name=version::$(echo $version)"

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -92,7 +92,10 @@ jobs:
         echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
         npm ci --unsafe-perm
         npm run build
-        artifact=$(npm pack)
+        # We run npm pack twice because the command may log extra stdout from the `prepare` script.
+        # We want all logs in CI, but we also want to capture just the artifact name.
+        npm pack
+        artifact="$(npm pack --foreground-scripts=false --json --dry-run | jq -r .[0].filename)"
         npm publish
         # version=$(jq -r .version package.json)
         echo "artifact=$(echo $artifact)" >> ${GITHUB_ENV}


### PR DESCRIPTION
# Description

Since upgrading to Node v20, which includes NPM v10.5, the `npm pack` command has begun outputting `stdout` from the project's `prepare` script as well (see ticket for more info). This broke the way we were capturing the artifact filename, so we need a workaround.

Since `npm pack` runs quickly, we thought it would be okay to run it twice - once for logging purposes on CI (and actually packing the artifact), and once again for parsing the artifact name (silent to CI logs).

# Associated tasks

None

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] ~I have updated the changelog.~
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] ~I have considered if this is a breaking change and will communicate it with other team members if so.~