### PR TITLE
Make product-key optional

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -74,6 +74,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       artifact_id: ${{ steps.check.outputs.artifact_id }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -109,6 +110,38 @@ jobs:
           artifact_id=$(cat ${{ inputs.version_file }} | grep "AssemblyTitle" | egrep -o "\"[A-Za-z0-9\-]+\"" | tr -d '"')
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
         shell: bash
+
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
 
   deploy:
     needs: release-checks
@@ -183,6 +216,7 @@ jobs:
   build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
     container: node:20-alpine

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -120,6 +120,27 @@ jobs:
             echo "Docs folder not found, will skip the build-docs"
           fi
 
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
 
   build-docs:
     needs: release-checks

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -6,7 +6,8 @@ on:
     inputs:
       product-key:
         description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: true
+        required: false
+        default: "productkeynotprovided"
         type: string
       private:
         description: 'Calling workflow from a private repo'
@@ -73,6 +74,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -104,15 +106,29 @@ jobs:
           /scripts/release-checks.sh --java --maven pom.xml
           /scripts/finalize-version.sh --java --maven pom.xml changelog.md
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
         shell: bash
+
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
 
 
   build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     steps:
       - name: Install Git
@@ -164,6 +180,29 @@ jobs:
           exit 1
         shell: sh
 
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
   deploy:
     needs: [release-checks, build-docs]
     runs-on: ubuntu-latest
@@ -205,10 +244,10 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}.jar"
-          echo "::set-output name=version::$(echo $version)"
-          echo "::set-output name=artifact::$(echo $artifact)"
-          echo "::set-output name=artifact-id::$(echo $artifactId)"
-          echo "::set-output name=artifact-path::$(echo target/$artifact)"
+          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
+          echo "artifact=$(echo $artifact)" >> "${GITHUB_OUTPUT}"
+          echo "artifact-id=$(echo $artifactId)" >> "${GITHUB_OUTPUT}"
+          echo "artifact-path=$(echo target/$artifact)" >> "${GITHUB_OUTPUT}"
         shell: bash
         continue-on-error: true
 
@@ -261,7 +300,7 @@ jobs:
           git push origin ${GITHUB_REF/refs\/heads\//}
           git tag "v${{ needs.release-checks.outputs.version }}"
           git push --tags
-          echo "::set-output name=tag::$(echo v${{ needs.release-checks.outputs.version }})"
+          echo "tag=$(echo v${{ needs.release-checks.outputs.version }})" >> "${GITHUB_OUTPUT}"
         shell: bash
         continue-on-error: true
 
@@ -327,7 +366,7 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: ${{ secrets.DOCS_REPO }}
           event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "https://github.com/${{ github.repository }}/releases/download/${{ steps.merge.outputs.tag }}/docs-site.zip"}'
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   # call-build-container:

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -6,7 +6,8 @@ on:
     inputs:
       product-key:
         description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: true
+        required: false
+        default: "productkeynotprovided"
         type: string
       private:
         description: 'Calling workflow from a private repo'
@@ -78,6 +79,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -112,11 +114,24 @@ jobs:
           echo "::set-output name=version::$(echo $version)"
         shell: bash
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
   build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     steps:
       - name: Install Git
@@ -167,6 +182,29 @@ jobs:
           echo "There was an error in the docusaurus build above."
           exit 1
         shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
 
   deploy:
     needs: [release-checks, build-docs]
@@ -338,7 +376,7 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: ${{ secrets.DOCS_REPO }}
           event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "https://github.com/${{ github.repository }}/releases/download/${{ steps.merge.outputs.tag }}/docs-site.zip"}'
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   update-version:

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -120,8 +120,30 @@ jobs:
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
             echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
           else
             echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
           fi
 
   build-docs:

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -5,7 +5,8 @@ on:
     inputs:
       product-key:
         description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: true
+        required: false
+        default: "productkeynotprovided"
         type: string
       private:
         description: 'Calling workflow from a private repo'
@@ -45,6 +46,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    outputs:
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,11 +79,48 @@ jobs:
           /scripts/finalize-version.sh --js package.json changelog.md
         shell: bash
 
+      - name: Check if docs present
+        id: docs
+        shell: bash
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
+
   build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -135,6 +175,30 @@ jobs:
           echo "There was an error in the docusaurus build above."
           exit 1
         shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
 
   build-artifact:
     needs: [build-docs, release-checks]
@@ -300,7 +364,7 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: ${{ secrets.DOCS_REPO }}
           event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "https://github.com/${{ github.repository }}/releases/download/${{ steps.merge.outputs.tag }}/docs-site.zip"}'
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   update-version:

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -8,10 +8,6 @@ on:
         required: false
         type: boolean
         default: true
-      product-key:
-        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: false
-        type: string
       licencecheck:
         description: 'Need to check licence headers/files'
         required: false
@@ -49,6 +45,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -95,9 +92,41 @@ jobs:
           # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
           echo "changelog=$(echo $changelog | base64 -w0)" >> $GITHUB_OUTPUT
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
   build-docs:
     needs: release-checks
-    if: ${{ inputs.product-key != '' }}
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     runs-on: ubuntu-latest
     outputs:
       artifact: docs

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -63,6 +63,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -97,11 +98,46 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
   build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     steps:
       - name: Install Git
@@ -152,6 +188,31 @@ jobs:
           echo "There was an error in the docusaurus build above."
           exit 1
         shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
+
 
   deploy:
     needs: [release-checks, build-docs]
@@ -314,7 +375,7 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: ${{ secrets.DOCS_REPO }}
           event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{ inputs.product-key }}", "download_url": "https://github.com/${{ github.repository }}/releases/download/${{ steps.merge.outputs.tag }}/docs-site.zip"}'
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   update-version:


### PR DESCRIPTION
This fix syncs the work done previously for the snapshot flows where "product-key" value is automatically detected from docs/docusaurus.conf.js to all other release-with-docs flows.

If the repo using any of these flows deploys documentation to a custom-named site, "product-key" can be overwritten in the appropriate github action in the repo.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [X] I have rebased onto the target branch (usually main).