### PR TITLE
Zipping docs before artefact upload in release workflows

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -255,11 +255,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
       - uses: actions/upload-artifact@master
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
 
       - name: Fail build
         if: steps.build.outcome == 'failure'

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -186,11 +186,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
       - uses: actions/upload-artifact@v3
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
           if-no-files-found: error
 
       - name: Fail build

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -190,11 +190,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
       - uses: actions/upload-artifact@v3
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
           if-no-files-found: error
 
       - name: Fail build

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -161,11 +161,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
       - uses: actions/upload-artifact@v3
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
           if-no-files-found: error
 
       - name: Fail build

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -174,11 +174,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: bash
+
       - uses: actions/upload-artifact@v3
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
           if-no-files-found: error
 
       - name: Fail build


### PR DESCRIPTION
# Description

Zip docs before uploading them as artefacts so that docs deployment can find them.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
~- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.~