### PR TITLE
Do not attach docs to release

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -336,20 +336,6 @@ jobs:
           ls built-artifacts
         shell: bash
 
-      - name: Download docs
-        uses: actions/download-artifact@v2
-        with:
-          name: docs
-          path: docs-site
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs-site
-          zip -r docs-site.zip .
-        shell: bash
-        continue-on-error: true
-
       - name: Get latest changelog
         id: changelog
         run: |
@@ -373,9 +359,7 @@ jobs:
           prerelease: false
           files: |
             built-artifacts/${{ needs.release-checks.outputs.artifact_id }}.zip
-            docs-site/docs-site.zip
         continue-on-error: true
-
 
   update-version:
     needs: [create-release]

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -346,20 +346,6 @@ jobs:
           path: built-artifacts
         continue-on-error: true
 
-      - name: Download docs
-        uses: actions/download-artifact@v3
-        with:
-          name: docs
-          path: docs-site
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs-site
-          zip -r docs-site.zip .
-        shell: bash
-        continue-on-error: true
-
       - name: Get latest changelog
         id: changelog
         run: |
@@ -384,7 +370,6 @@ jobs:
           prerelease: false
           files: |
             built-artifacts/${{ needs.deploy.outputs.artifact }}
-            docs-site/docs-site.zip
         continue-on-error: true
 
       - name: Deploy documentation

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -357,20 +357,6 @@ jobs:
           path: built-artifacts
         continue-on-error: true
 
-      - name: Download docs
-        uses: actions/download-artifact@v3
-        with:
-          name: docs
-          path: docs-site
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs-site
-          zip -r docs-site.zip .
-        shell: bash
-        continue-on-error: true
-
       - name: Get latest changelog
         id: changelog
         run: |
@@ -395,7 +381,6 @@ jobs:
           prerelease: false
           files: |
             built-artifacts/${{ needs.deploy.outputs.artifact }}
-            docs-site/docs-site.zip
         continue-on-error: true
 
       - name: Deploy documentation

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -301,20 +301,6 @@ jobs:
           git config --global --add safe.directory /__w/$dname/$dname
         shell: sh
 
-      - name: Download docs
-        uses: actions/download-artifact@v3
-        with:
-          name: docs
-          path: docs-site
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs-site
-          zip -r docs-site.zip .
-        shell: bash
-        continue-on-error: true
-
       - name: Get latest changelog
         id: changelog
         run: |
@@ -361,7 +347,6 @@ jobs:
           prerelease: false
           files: |
             built-artifacts/${{ needs.build-artifact.outputs.artifact }}
-            docs-site/docs-site.zip
         continue-on-error: true
 
       - name: Deploy documentation

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -335,20 +335,6 @@ jobs:
           path: built-artifacts
         continue-on-error: true
 
-      - name: Download docs
-        uses: actions/download-artifact@v3
-        with:
-          name: docs
-          path: docs-site
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs-site
-          zip -r docs-site.zip .
-        shell: bash
-        continue-on-error: true
-
       - name: Get latest changelog
         id: changelog
         run: |
@@ -372,7 +358,6 @@ jobs:
           prerelease: false
           files: |
             built-artifacts/${{ needs.deploy.outputs.artifact }}
-            docs-site/docs-site.zip
         continue-on-error: true
 
       - name: Deploy documentation


### PR DESCRIPTION
# Description

We do not need to attach docs site to the release anymore as the deployment happens via a different repo action.

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
~- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.~