### PR TITLE
Pin leftover pipeline-java containers to 4.4.0

### DIFF
--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
-    container: zepben/pipeline-java
+    container: zepben/pipeline-java:4.4.0
     steps:
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
-    container: zepben/pipeline-java
+    container: zepben/pipeline-java:4.4.0
     steps:
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/maven-lib-snapshot.yml
+++ b/.github/workflows/maven-lib-snapshot.yml
@@ -108,7 +108,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-java
+    container: zepben/pipeline-java:4.4.0
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

Pin the leftover `pipeline-java` containers missed in #38  to version 4.4.0.


### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~