### PR TITLE
Add version output to all app CI jobs

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -60,6 +60,7 @@ on:
       version:
         description: "The current released version."
         value: ${{ jobs.release-checks.outputs.version }}
+
 jobs:
   release-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -1,6 +1,6 @@
 name: CSharp App Release With Docs
 
-on: 
+on:
   workflow_call:
     inputs:
       test_files:
@@ -47,16 +47,19 @@ on:
         required: true
       NEXUS_USERNAME:
         required: true
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: true
       SLACK_NOTIFICATION:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
-
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
@@ -121,7 +124,7 @@ jobs:
         run: |
           # Make sure directories are properly ignored
           # docs/node_modules
-          git check-ignore -q docs/node_modules 
+          git check-ignore -q docs/node_modules
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -129,7 +132,7 @@ jobs:
           fi
 
           # docs/build
-          git check-ignore -q docs/build 
+          git check-ignore -q docs/build
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/build' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
@@ -154,10 +157,10 @@ jobs:
           git fetch --all
           git checkout release
         shell: bash
-      
+
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
-      
+
       - name: Setup MSBuild Path
         uses: microsoft/setup-msbuild@v1
 
@@ -166,9 +169,9 @@ jobs:
 
       - name: Add ZepBen Nuget Repo credentials
         run: nuget sources update -Name "ZepBen" -username "${{ secrets.NEXUS_USERNAME }}" -password "${{ secrets.NEXUS_PASSWORD }}" -configFile "Nuget.Config"
-      
+
       - name: Restore NuGet Packages
-        run:   
+        run:
           msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
 
       - name: Build

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -1,6 +1,6 @@
 name: CSharp App Release
 
-on: 
+on:
   workflow_call:
     inputs:
       test_files:
@@ -47,15 +47,19 @@ on:
         required: true
       NEXUS_USERNAME:
         required: true
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: true
       SLACK_NOTIFICATION:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
 
 jobs:
   release-checks:
@@ -121,10 +125,10 @@ jobs:
           git fetch --all
           git checkout release
         shell: bash
-      
+
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.0.5
-      
+
       - name: Setup MSBuild Path
         uses: microsoft/setup-msbuild@v1
 
@@ -133,9 +137,9 @@ jobs:
 
       - name: Add ZepBen Nuget Repo credentials
         run: nuget sources update -Name "ZepBen" -username "${{ secrets.NEXUS_USERNAME }}" -password "${{ secrets.NEXUS_PASSWORD }}" -configFile "Nuget.Config"
-      
+
       - name: Restore NuGet Packages
-        run:   
+        run:
           msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
 
       - name: Build

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -1,6 +1,6 @@
 name: CSharp App Snapshot
- 
-on: 
+
+on:
   workflow_call:
     inputs:
       test_files:
@@ -52,16 +52,22 @@ on:
         required: true
       NEXUS_USERNAME:
         required: false
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
+
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.build.outputs.version }}
 
 jobs:
   build:
     runs-on: windows-2019
     outputs:
       docs-present: ${{ steps.docs.outputs.present }}
+      version: ${{ steps.update-info-version.outputs.info_version }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -77,10 +83,10 @@ jobs:
       with:
         LC_URL: ${{ secrets.LC_URL }}
         PATH: ${{ inputs.sourcepath }}
-  
+
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
-     
+
     - name: Setup MSBuild Path
       uses: microsoft/setup-msbuild@v1
 
@@ -102,9 +108,9 @@ jobs:
 
     - name: Add ZepBen Nuget Repo credentials
       run: nuget sources update -Name "ZepBen" -username "${{ secrets.NEXUS_USERNAME }}" -password "${{ secrets.NEXUS_PASSWORD }}" -configFile "Nuget.Config"
-     
+
     - name: Restore NuGet Packages
-      run:   
+      run:
         msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
 
     - name: Build
@@ -156,7 +162,7 @@ jobs:
       run: |
         # Make sure directories are properly ignored
         # docs/node_modules
-        git check-ignore -q docs/node_modules 
+        git check-ignore -q docs/node_modules
         if [ $? != 0 ]; then
             echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
             echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -164,7 +170,7 @@ jobs:
         fi
 
         # docs/build
-        git check-ignore -q docs/build 
+        git check-ignore -q docs/build
         if [ $? != 0 ]; then
             echo "ERROR! Make sure to add 'docs/build' to .gitignore"
             echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -1,7 +1,7 @@
 # Note: default release notes file is docs/release.md.
 name: Maven App Release
 
-on: 
+on:
   workflow_call:
     inputs:
       private:
@@ -21,7 +21,7 @@ on:
         required: true
       NEXUS_USERNAME:
         required: true
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: true
       NEXUS_MAVEN_SNAPSHOT:
         required: true
@@ -31,10 +31,14 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
@@ -134,7 +138,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: steps.build.outcome == 'success'
         uses: codecov/codecov-action@v3
-        with: 
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -92,7 +92,6 @@ jobs:
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}.jar"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
-          echo "::set-output name=version::$(echo $version)"
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
           echo "artifact-path=$(echo target/$artifact)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -30,7 +30,7 @@ on:
         required: false
       NEXUS_USERNAME:
         required: false
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: false
       NEXUS_MAVEN_SNAPSHOT:
         required: false
@@ -44,16 +44,20 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.build-app.outputs.version }}
 jobs:
   build-app:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java-ewb
     outputs:
       docs-present: ${{ steps.docs.outputs.present }}
-
+      version: ${{ steps.build.outputs.version }}
     env:
       GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
       GPG_KEY_PASSWORD: ${{ secrets.GPG_KEY_PASSWORD }}
@@ -88,6 +92,7 @@ jobs:
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}.jar"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
+          echo "::set-output name=version::$(echo $version)"
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
           echo "artifact-path=$(echo target/$artifact)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
@@ -126,7 +131,7 @@ jobs:
         run: |
           # Make sure directories are properly ignored
           # docs/node_modules
-          git check-ignore -q docs/node_modules 
+          git check-ignore -q docs/node_modules
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -134,7 +139,7 @@ jobs:
           fi
 
           # docs/build
-          git check-ignore -q docs/build 
+          git check-ignore -q docs/build
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/build' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -1,6 +1,6 @@
 name: NPM Static App Release
 
-on: 
+on:
   workflow_call:
     inputs:
       product-key:
@@ -29,9 +29,13 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.build-artifact.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
@@ -90,7 +94,7 @@ jobs:
         run: |
           # Make sure directories are properly ignored
           # docs/node_modules
-          git check-ignore -q docs/node_modules 
+          git check-ignore -q docs/node_modules
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -98,7 +102,7 @@ jobs:
           fi
 
           # docs/build
-          git check-ignore -q docs/build 
+          git check-ignore -q docs/build
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/build' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
@@ -242,7 +246,7 @@ jobs:
         shell: sh
 
       - name: create .npmrc
-        run: | 
+        run: |
           rm -rf .npmrc
           echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> .npmrc
           echo "//mavenrepo.zepben.com/repository/zepben-npm/:_authToken=${{ secrets.CI_NPM_TOKEN }}" >> .npmrc
@@ -269,7 +273,7 @@ jobs:
 
       - name: Fail build
         if: steps.build.outcome == 'failure'
-        run: | 
+        run: |
           git push origin -d release
           echo "There was an error in the npm package command above."
           exit 1
@@ -306,7 +310,7 @@ jobs:
 
       - name: Merge and Tag
         id: merge
-        run: | 
+        run: |
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
           git fetch --all
           git merge origin/release
@@ -321,7 +325,7 @@ jobs:
 
       - name: Fail
         if: steps.merge.outcome == 'failure'
-        run: | 
+        run: |
           git push origin -d release
           echo "There was an error in merging the branch. release branch was deleted."
           exit 1

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -1,6 +1,6 @@
 name: NPM Static App Release
 
-on: 
+on:
   workflow_call:
     inputs:
       private:
@@ -24,9 +24,13 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
@@ -102,7 +106,7 @@ jobs:
         run: |
           # Make sure directories are properly ignored
           # docs/node_modules
-          git check-ignore -q docs/node_modules 
+          git check-ignore -q docs/node_modules
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -110,7 +114,7 @@ jobs:
           fi
 
           # docs/build
-          git check-ignore -q docs/build 
+          git check-ignore -q docs/build
           if [ $? != 0 ]; then
               echo "ERROR! Make sure to add 'docs/build' to .gitignore"
               echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
@@ -220,7 +224,7 @@ jobs:
         shell: sh
 
       - name: create .npmrc
-        run: | 
+        run: |
           rm -rf .npmrc
           echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> .npmrc
           echo "//mavenrepo.zepben.com/repository/zepben-npm/:_authToken=${{ secrets.CI_NPM_TOKEN }}" >> .npmrc
@@ -248,7 +252,7 @@ jobs:
 
       - name: Fail build
         if: steps.build.outcome == 'failure'
-        run: | 
+        run: |
           git push origin -d release
           echo "There was an error in the npm package command above."
           exit 1
@@ -283,19 +287,19 @@ jobs:
         continue-on-error: false
 
       - name: Check artifact
-        run: | 
+        run: |
           ls -la
           ls -la built-artifacts
         shell: sh
 
       - name: Merge and Tag
         id: merge
-        run: | 
+        run: |
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
           git fetch --all
           git merge origin/release
           git push origin ${GITHUB_REF/refs\/heads\//}
-          tag="v${{ needs.release-checks.outputs.version }}" 
+          tag="v${{ needs.release-checks.outputs.version }}"
           git tag $tag
           git push --tags
           echo "tag=$tag" >> $GITHUB_OUTPUT
@@ -304,7 +308,7 @@ jobs:
 
       - name: Fail
         if: steps.merge.outcome == 'failure'
-        run: | 
+        run: |
           git push origin -d release
           echo "There was an error in merging the branch. release branch was deleted."
           exit 1
@@ -319,7 +323,7 @@ jobs:
 
       - name: Tell user to release themselves
         if: steps.changelog.outcome == 'failure'
-        run: | 
+        run: |
           echo "There was an error generating a changelog to associate with the release (see previous step and step in release-checks). You'll need to:"
           echo "1. Fix the changelog"
           echo "2. Manually create the release"
@@ -344,7 +348,7 @@ jobs:
 
       - name: Fail Release
         if: steps.create_release.outcome == 'failure'
-        run: | 
+        run: |
           git push origin -d release
           echo "There was an error in the npm package release above."
           exit 1

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -34,14 +34,19 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL: 
+      LC_URL:
         required: false
 
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.build-artifact.outputs.version }}
 jobs:
   build-artifact:
     runs-on: ubuntu-latest
     outputs:
       docs-present: ${{ steps.docs.outputs.present }}
+      version: ${{ steps.build.outputs.version }}
     container: node:20-alpine
     steps:
     - name: Install Dependencies
@@ -73,7 +78,7 @@ jobs:
         setup-timezone -z Australia/ACT
 
     - name: create .npmrc
-      run: | 
+      run: |
         rm -rf ~/.npmrc
         echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> ~/.npmrc
         echo "//mavenrepo.zepben.com/repository/zepben-npm/:_authToken=${{ secrets.CI_NPM_TOKEN }}" >> ~/.npmrc
@@ -86,11 +91,12 @@ jobs:
         echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
         npm ci --unsafe-perm
         npm run prod
-        # version=$(jq -r .version package.json)
+        version=$(jq -r .version package.json)
         artifactId=$(jq -r .name package.json)
         artifact="$artifactId-$version-SNAPSHOT.tar.bz2"
         tar jcvf "$artifact" -C dist .
         echo "artifact=$artifact" >> ${GITHUB_ENV}
+        echo "version=$version" >> ${GITHUB_ENV}
 
     - uses: actions/upload-artifact@v3
       if: steps.build.outcome == 'success'
@@ -122,7 +128,7 @@ jobs:
       run: |
         # Make sure directories are properly ignored
         # docs/node_modules
-        git check-ignore -q docs/node_modules 
+        git check-ignore -q docs/node_modules
         if [ $? != 0 ]; then
             echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
             echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
@@ -130,7 +136,7 @@ jobs:
         fi
 
         # docs/build
-        git check-ignore -q docs/build 
+        git check-ignore -q docs/build
         if [ $? != 0 ]; then
             echo "ERROR! Make sure to add 'docs/build' to .gitignore"
             echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"


### PR DESCRIPTION
# Description

I'm working on some docker image build workflows that would allow us to easily have containers built/tagged in a consistent way. In order to have consistent tagging, I want to reuse the version numbers that we use when building releases/snapshots etc. 

This PR adds the version as outputs to all reusable workflows that build apps. Recommend reviewing while hiding whitespace since VScode removed alot of the extra spaces floating around.

# Test Steps

In production lol

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] ~I have updated the changelog.~ N/A
- [ ] ~I have updated any documentation required for these changes.~ N/A

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

