### PR TITLE
[OPS-254] Fix latest changelog parameter for shell expansion

### DIFF
--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -87,7 +87,8 @@ jobs:
             exit 1
           fi
           # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
-          echo "changelog=$(echo $changelog | base64 -w0)" >> $GITHUB_OUTPUT
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
       - name: Check if docs present
         id: docs


### PR DESCRIPTION
# Description

We store the last segment of the changelog.md in a variable. It includes `*` sign (for example, `* None`); when later used without quotes, it globs and shell fills in all the files in the local directory and removes all the new lines.

This fix quotes the variable and allows to use it literally.

# Test Steps

The release in a  test repo https://github.com/zepben/npm-app-ci-test/releases/tag/v1.25.0 was built with this branch.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
