### PR TITLE
[OPS-257] Sync upload and download artefact versions for maven lib release

### DIFF
--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -340,7 +340,7 @@ jobs:
         shell: bash
 
       - name: Download binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.deploy.outputs.artifact }}
           path: built-artifacts

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -196,7 +196,7 @@ jobs:
         shell: bash
 
       - name: Download binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.deploy.outputs.artifact }}
           path: built-artifacts


### PR DESCRIPTION
Upload and download artefact versions have to be the same to work properly.


### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).