### PR TITLE
[OPS-262] Fail python build quickly if not all dependencies are available

### DIFF
--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -76,7 +76,7 @@ jobs:
           /scripts/release-checks.sh --python setup.py
           /scripts/finalize-version.sh --python setup.py
           version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
-          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Cache licence-check

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -76,7 +76,7 @@ jobs:
           /scripts/release-checks.sh --python setup.py
           /scripts/finalize-version.sh --python setup.py
           version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Cache licence-check
@@ -123,8 +123,22 @@ jobs:
               exit 1
           fi
 
-  build-docs:
+  python-deps-check:
     needs: release-checks
+    runs-on: ubuntu-latest
+    container: python:3.9
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test install the local package with deps
+        run: |
+          # finalize-version above removes all snapshot/test versions
+          # from zepben packages. Now let's try to install to see if deps exist or fail quick
+          pip install --pre '.'
+
+
+  build-docs:
+    needs: [release-checks, python-deps-check]
     runs-on: ubuntu-latest
     if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -67,7 +67,7 @@ jobs:
           /scripts/release-checks.sh --python setup.py
           /scripts/finalize-version.sh --python setup.py changelog.md
           version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Cache licence-check
@@ -82,8 +82,21 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
+  python-deps-check:
+    needs: release-checks
+    runs-on: ubuntu-latest
+    container: python:3.9
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test install the local package with deps
+        run: |
+          # finalize-version above removes all snapshot/test versions
+          # from zepben packages. Now let's try to install to see if deps exist or fail quick
+          pip install --pre '.'
+
   deploy:
-    needs: [release-checks]
+    needs: [release-checks, python-deps-check]
     runs-on: ubuntu-latest
     container: python:3.9
     outputs:


### PR DESCRIPTION
# Description

When we release our python packages, we strip all snapshot versions from the project, including itself AND various dependencies. To make sure those dependencies have been actually released, we want to fail build here if they haven't been, so this PR is adding a step in the workflow that basically will try to install all those dependencies and fail if they are not present.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
- [x] I have updated any documentation required for these changes.