### PR TITLE
Add sealed image workflow for public repos

### DIFF
--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -1,0 +1,89 @@
+name: Build Sealed Docker Image
+on:
+  workflow_call:
+    inputs:
+      version_tag:
+        description: Precomputed version tag to use as a Docker image tag
+        type: string
+        default: ''
+      latest_tag:
+        description: If the image should be tagged with 'latest'. Should only be used for release builds
+        type: boolean
+        default: false
+      edge_tag:
+        description: If the image should be tagged with 'edge'. Should only be used for snapshot builds
+        type: boolean
+        default: false
+      push_image:
+        description: If the image should be pushed to GHCR
+        type: boolean
+        default: false
+      dockerfile:
+        description: Override the Dockerfile in use
+        type: string
+        default: 'Dockerfile'
+      build-args:
+        description: Build args for building the Dockerfile
+        required: false
+        type: string
+        default: ''
+      commit:
+        description: Override the commit to build the container on
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CI_GITHUB_TOKEN:
+        required: true
+
+env:
+  REGISTRY_URL: "ghcr.io/${{ github.repository }}"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      # Priority sorting determines the tag used in the OCI label
+      # The current order preferences the version, then commit, then any special tags
+      # We always push a commit based tag
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_URL }}
+          tags: |
+            type=sha,format=short,priority=200
+            type=sha,format=long,priority=220
+            type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
+            type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
+            type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.dockerfile }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: ${{ inputs.build-args }}

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -32,34 +32,41 @@ on:
         required: false
         type: string
         default: ''
+      skip_repo_login:
+        description: Skip repository logins
+        required: false
+        type: boolean
+        default: false
     secrets:
       CI_GITHUB_TOKEN:
         required: true
 
       # Nexus Login
       NEXUS_USERNAME:
-        required: true
+        required: false
       NEXUS_PASSWORD:
-        required: true
+        required: false
 
       # Maven
       NEXUS_MAVEN_REPO:
-        required: true
+        required: false
       NEXUS_MAVEN_SNAPSHOT:
-        required: true
+        required: false
       NEXUS_MAVEN_RELEASE:
-        required: true
+        required: false
 
       # NPM
       NEXUS_NPM_REPO:
-        required: true
+        required: false
 
       # Nuget
       NEXUS_NUGET_FEED:
-        required: true
+        required: false
 
 env:
   REGISTRY_URL: "ghcr.io/${{ github.repository }}"
+  RUN_REPO_LOGIN: ${{ ! inputs.skip_repo_login }}
+
 
 jobs:
   build:
@@ -74,6 +81,7 @@ jobs:
           ref: ${{ inputs.commit }}
 
       - name: Login to NPM
+        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         run: |
           rm -rf ~/.npmrc
           echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> ~/.npmrc
@@ -83,6 +91,7 @@ jobs:
 
       - name: Login to Maven
         uses: zepben/maven-login@main
+        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         with:
           maven-repo-url: ${{ secrets.NEXUS_MAVEN_REPO }}
           maven-release-url: ${{ secrets.NEXUS_MAVEN_RELEASE }}
@@ -91,8 +100,16 @@ jobs:
           server-password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Login to Nuget
+        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         run: |
           dotnet nuget add source "${{ secrets.NEXUS_NUGET_FEED }}" --name "Zepben" --username "${{ secrets.NEXUS_USERNAME }}" --password "${{ secrets.NEXUS_PASSWORD }}" --store-password-in-clear-text
+
+      - name: Fake secret files
+        if: ${{ env.RUN_REPO_LOGIN == 'false' }}
+        run: |
+          echo fake > /home/runner/.npmrc
+          echo fake > /home/runner/.m2/settings.xml
+          echo fake > /home/runner/.nuget/NuGet/NuGet.Config
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -32,41 +32,34 @@ on:
         required: false
         type: string
         default: ''
-      skip_repo_login:
-        description: Skip repository logins
-        required: false
-        type: boolean
-        default: false
     secrets:
       CI_GITHUB_TOKEN:
         required: true
 
       # Nexus Login
       NEXUS_USERNAME:
-        required: false
+        required: true
       NEXUS_PASSWORD:
-        required: false
+        required: true
 
       # Maven
       NEXUS_MAVEN_REPO:
-        required: false
+        required: true
       NEXUS_MAVEN_SNAPSHOT:
-        required: false
+        required: true
       NEXUS_MAVEN_RELEASE:
-        required: false
+        required: true
 
       # NPM
       NEXUS_NPM_REPO:
-        required: false
+        required: true
 
       # Nuget
       NEXUS_NUGET_FEED:
-        required: false
+        required: true
 
 env:
   REGISTRY_URL: "ghcr.io/${{ github.repository }}"
-  RUN_REPO_LOGIN: ${{ ! inputs.skip_repo_login }}
-
 
 jobs:
   build:
@@ -81,7 +74,6 @@ jobs:
           ref: ${{ inputs.commit }}
 
       - name: Login to NPM
-        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         run: |
           rm -rf ~/.npmrc
           echo "@zepben:registry=${{ secrets.NEXUS_NPM_REPO }}" >> ~/.npmrc
@@ -91,7 +83,6 @@ jobs:
 
       - name: Login to Maven
         uses: zepben/maven-login@main
-        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         with:
           maven-repo-url: ${{ secrets.NEXUS_MAVEN_REPO }}
           maven-release-url: ${{ secrets.NEXUS_MAVEN_RELEASE }}
@@ -100,16 +91,8 @@ jobs:
           server-password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Login to Nuget
-        if: ${{ env.RUN_REPO_LOGIN == 'true' }}
         run: |
           dotnet nuget add source "${{ secrets.NEXUS_NUGET_FEED }}" --name "Zepben" --username "${{ secrets.NEXUS_USERNAME }}" --password "${{ secrets.NEXUS_PASSWORD }}" --store-password-in-clear-text
-
-      - name: Fake secret files
-        if: ${{ env.RUN_REPO_LOGIN == 'false' }}
-        run: |
-          echo fake > /home/runner/.npmrc
-          echo fake > /home/runner/.m2/settings.xml
-          echo fake > /home/runner/.nuget/NuGet/NuGet.Config
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
# Description

Similar to #49, but adds a workflow that doesn't log into any of our private repos so that we can used it to build images in public repos