### PR TITLE
Fix invalid tags on docker image

### DIFF
--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -64,11 +64,16 @@ jobs:
       # Priority sorting determines the tag used in the OCI label
       # The current order preferences the version, then commit, then any special tags
       # We always push a commit based tag
+      #
+      # The context also must be git cause there is a potential for us to override the currently checked out commit
+      # using `inputs.commit`. Therefore we should tag the image with that commit instead of whatever random event
+      # that Github sends
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
+          context: git
           tags: |
             type=sha,format=short,priority=200
             type=sha,format=long,priority=220

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -108,11 +108,16 @@ jobs:
       # Priority sorting determines the tag used in the OCI label
       # The current order preferences the version, then commit, then any special tags
       # We always push a commit based tag
+      #
+      # The context also must be git cause there is a potential for us to override the currently checked out commit
+      # using `inputs.commit`. Therefore we should tag the image with that commit instead of whatever random event
+      # that Github sends
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
+          context: git
           tags: |
             type=sha,format=short,priority=200
             type=sha,format=long,priority=220


### PR DESCRIPTION
# Description

When overriding the commit and dispatching the docker build we need to ensure the final image is tagged correctly. In order to do this, we need to tell the build to use git as the source of truth instead of the workflow event.