### PR TITLE
Manually resolve git tags for docker image builds

### DIFF
--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get Short SHA
         id: sha
         run: |
-          SHORT_REF=git rev-parse --short HEAD
+          SHORT_REF=$(git rev-parse --short HEAD)
           echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
 
+      - name: Get Short SHA
+        id: sha
+        run: |
+          SHORT_REF=git rev-parse --short HEAD
+          echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -70,8 +76,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY_URL }}
           tags: |
-            type=sha,format=short,priority=200
-            type=sha,format=long,priority=220
+            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
+            type=raw,value=sha-${{ inputs.commit }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -64,16 +64,11 @@ jobs:
       # Priority sorting determines the tag used in the OCI label
       # The current order preferences the version, then commit, then any special tags
       # We always push a commit based tag
-      #
-      # The context also must be git cause there is a potential for us to override the currently checked out commit
-      # using `inputs.commit`. Therefore we should tag the image with that commit instead of whatever random event
-      # that Github sends
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
-          context: git
           tags: |
             type=sha,format=short,priority=200
             type=sha,format=long,priority=220

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -47,6 +47,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit }}
@@ -77,7 +78,7 @@ jobs:
           images: ${{ env.REGISTRY_URL }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ inputs.commit }},priority=220
+            type=raw,value=sha-${{ steps.checkout.outputs.ref }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -69,6 +69,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit }}
@@ -121,7 +122,7 @@ jobs:
           images: ${{ env.REGISTRY_URL }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ inputs.commit }},priority=220
+            type=raw,value=sha-${{ steps.checkout.outputs.ref }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -73,6 +73,12 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
 
+      - name: Get Short SHA
+        id: sha
+        run: |
+          SHORT_REF=git rev-parse --short HEAD
+          echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
+
       - name: Login to NPM
         run: |
           rm -rf ~/.npmrc
@@ -114,8 +120,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY_URL }}
           tags: |
-            type=sha,format=short,priority=200
-            type=sha,format=long,priority=220
+            type=sha,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
+            type=raw,value=sha-${{ inputs.commit }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Get Short SHA
         id: sha
         run: |
-          SHORT_REF=git rev-parse --short HEAD
+          SHORT_REF=$(git rev-parse --short HEAD)
           echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
 
       - name: Login to NPM

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -108,16 +108,11 @@ jobs:
       # Priority sorting determines the tag used in the OCI label
       # The current order preferences the version, then commit, then any special tags
       # We always push a commit based tag
-      #
-      # The context also must be git cause there is a potential for us to override the currently checked out commit
-      # using `inputs.commit`. Therefore we should tag the image with that commit instead of whatever random event
-      # that Github sends
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
-          context: git
           tags: |
             type=sha,format=short,priority=200
             type=sha,format=long,priority=220

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_URL }}
           tags: |
-            type=sha,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
+            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
             type=raw,value=sha-${{ inputs.commit }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100


### PR DESCRIPTION
# Description

Reverts #57. Seems there is an issue with fetching the git details when in detached mode. So instead we compute the git sha ourselves. There appears to be a closed issue regarding this in the metadata action repository, but no solution or workaround (https://github.com/docker/metadata-action/issues/362)