### PR TITLE
Fix container builds to use correct tags

### DIFF
--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_URL }}
           labels: |
-            org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
+            org.opencontainers.image.vendor=Zepben
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},enable=${{ inputs.sha-tags }},priority=200
             type=raw,value=sha-${{ steps.sha.outputs.long_ref }},enable=${{ inputs.sha-tags }},priority=220

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ''
+      sha-tags:
+        description: Override if we should push SHA based tags. Should be false for bundled containers
+        required: false
+        type: boolean
+        default: true
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -80,8 +85,8 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
           tags: |
-            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220
+            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},enable=${{ inputs.sha-tags }},priority=200
+            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},enable=${{ inputs.sha-tags }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -77,6 +77,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
             type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220

--- a/.github/workflows/build-sealed-docker-image-public.yml
+++ b/.github/workflows/build-sealed-docker-image-public.yml
@@ -47,16 +47,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit }}
 
-      - name: Get Short SHA
+      - name: Get SHAs
         id: sha
         run: |
           SHORT_REF=$(git rev-parse --short HEAD)
+          LONG_REF=$(git rev-parse HEAD)
           echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
+          echo "long_ref=$LONG_REF" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -78,7 +79,7 @@ jobs:
           images: ${{ env.REGISTRY_URL }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ steps.checkout.outputs.ref }},priority=220
+            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ''
+      sha-tags:
+        description: Override if we should push SHA based tags. Should be false for bundled containers
+        required: false
+        type: boolean
+        default: true
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -124,8 +129,8 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
           tags: |
-            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220
+            type=raw,value=sha-${{ steps.sha.outputs.short_ref }},enable=${{ inputs.sha-tags }},priority=200
+            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},enable=${{ inputs.sha-tags }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -69,16 +69,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit }}
 
-      - name: Get Short SHA
+      - name: Get SHAs
         id: sha
         run: |
           SHORT_REF=$(git rev-parse --short HEAD)
+          LONG_REF=$(git rev-parse HEAD)
           echo "short_ref=$SHORT_REF" >> $GITHUB_OUTPUT
+          echo "long_ref=$LONG_REF" >> $GITHUB_OUTPUT
 
       - name: Login to NPM
         run: |
@@ -122,7 +123,7 @@ jobs:
           images: ${{ env.REGISTRY_URL }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
-            type=raw,value=sha-${{ steps.checkout.outputs.ref }},priority=220
+            type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220
             type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' }},priority=900
             type=raw,value=edge,enable=${{ inputs.edge_tag }},priority=100
             type=raw,value=latest,enable=${{ inputs.latest_tag }},priority=100

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_URL }}
           labels: |
-            org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
+            org.opencontainers.image.vendor=Zepben
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},enable=${{ inputs.sha-tags }},priority=200
             type=raw,value=sha-${{ steps.sha.outputs.long_ref }},enable=${{ inputs.sha-tags }},priority=220

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -121,6 +121,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_URL }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.sha.outputs.long_ref }}
           tags: |
             type=raw,value=sha-${{ steps.sha.outputs.short_ref }},priority=200
             type=raw,value=sha-${{ steps.sha.outputs.long_ref }},priority=220


### PR DESCRIPTION
# Description

Follow up to #58, the PR:

- Fixes the Get SHA step to return the correct long sha, instead of `checkout.ref` since it is not set on branches
- Allows supression of sha-based tags, useful for builds that have bundled containers (EAS/UI)
- Add the open container vendor tag