### PR TITLE
[OPS-207] Fetch last section of the changelog with one sed command

### DIFF
--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     continue-on-error: false
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -61,10 +63,27 @@ jobs:
           PATH: ${{ inputs.sourcepath }}
 
       - name: Release checks and update version for release
+        id: check
         run: |
           /scripts/release-checks.sh --js package.json
           /scripts/finalize-version.sh --js package.json changelog.md
+          version=$(jq -r .version package.json)
+          echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
+
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
   build-artifact:
     needs: release-checks
@@ -147,7 +166,7 @@ jobs:
         shell: sh
 
   create-release:
-    needs: [build-artifact]
+    needs: [build-artifact, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -169,10 +188,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 
@@ -199,8 +215,8 @@ jobs:
           version=$(jq -r .version package.json)
           git tag "v$version"
           git push --tags
-          echo "::set-output name=tag::$(echo v$version)"
-          echo "::set-output name=artifact::$(echo ${{ needs.build-artifact.outputs.artifact }})"
+          echo "tag=v$version" >> $GITHUB_OUTPUT
+          echo "artifact=${{ needs.build-artifact.outputs.artifact }}" >> $GITHUB_OUTPUT
         shell: bash
         continue-on-error: true
 


### PR DESCRIPTION
# Description

Update the "last_changelog" section fetch to use one sed command to potentially avoid pipe errors in the Linux shell. Also fail early if the `changelog.md` content is incorrect/can't be parsed properly.


# Test Steps

Tested with a test repository https://github.com/zepben/npm-lib-ci-test/actions/runs/11927040545

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This is not a breaking change.