### PR TITLE
Ops 279 multiple artifacts maven

### DIFF
--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -263,14 +263,17 @@ jobs:
       - name: Maven package
         id: build
         run: |
-          mvn clean package -B -f pom.xml -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE  
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}.jar"
-          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
-          echo "artifact=$(echo $artifact)" >> "${GITHUB_OUTPUT}"
-          echo "artifact-id=$(echo $artifactId)" >> "${GITHUB_OUTPUT}"
-          echo "artifact-path=$(echo target/$artifact)" >> "${GITHUB_OUTPUT}"
+          artifact="${artifactId}-${version}"
+          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
+          mkdir .artifact-$artifact
+          cp target/* -t .artifact-$artifact || :
+          rm .artifact-$artifact/original*.jar || :
+          echo "version=$(echo $version)" >> ${GITHUB_OUTPUT}
+          echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
+          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
+          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
         shell: bash
         continue-on-error: true
 
@@ -287,6 +290,8 @@ jobs:
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
+          include-hidden-files: true
+          if-no-files-found: error
 
       - name: Delete release branch if deploy failed and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -272,7 +272,7 @@ jobs:
           rm .artifact-$artifact/original*.jar || :
           echo "version=$(echo $version)" >> ${GITHUB_OUTPUT}
           echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
-          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
+          echo "artifact-id=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
         shell: bash
         continue-on-error: true

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -121,11 +121,10 @@ jobs:
       - name: Maven package
         id: build
         run: |
-          mvn clean package -B -f pom.xml -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dnexus.signature=$NEXUS_SIGNATURE -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}"
-          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
+          mvn clean package -B -f pom.xml -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dnexus.signature=$NEXUS_SIGNATURE -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
           rm .artifact-$artifact/original*.jar || :

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -125,13 +125,14 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}"
-          echo "version=$(echo $version)" >> ${GITHUB_ENV}
-          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
           rm .artifact-$artifact/original*.jar || :
+          echo "version=$(echo $version)" >> ${GITHUB_OUTPUT}
+          echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
+          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
+          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
 
         shell: bash
         env:

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -131,7 +131,7 @@ jobs:
           rm .artifact-$artifact/original*.jar || :
           echo "version=$(echo $version)" >> ${GITHUB_OUTPUT}
           echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
-          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
+          echo "artifact-id=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
 
         shell: bash

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -131,7 +131,7 @@ jobs:
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
-          rm .artifact-$artifact/original*.jar
+          rm .artifact-$artifact/original*.jar || :
 
         shell: bash
         env:

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -210,8 +210,8 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.deploy.outputs.artifact }}
           path: built-artifacts
+          merge-multiple: true
         continue-on-error: true
 
       - name: Get latest changelog
@@ -236,7 +236,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            built-artifacts/${{ needs.deploy.outputs.artifact }}
+            built-artifacts/*
         continue-on-error: true
 
 

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -124,11 +124,15 @@ jobs:
           mvn clean package -B -f pom.xml -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dnexus.signature=$NEXUS_SIGNATURE -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}.jar"
-          echo "::set-output name=version::$(echo $version)"
-          echo "::set-output name=artifact::$(echo $artifact)"
-          echo "::set-output name=artifact-id::$(echo $artifactId)"
-          echo "::set-output name=artifact-path::$(echo target/$artifact)"
+          artifact="${artifactId}-${version}"
+          echo "version=$(echo $version)" >> ${GITHUB_ENV}
+          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
+          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO
+          mkdir .artifact-$artifact
+          cp target/* -t .artifact-$artifact || :
+          rm .artifact-$artifact/original*.jar
+
         shell: bash
         env:
           NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
@@ -153,6 +157,7 @@ jobs:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
           if-no-files-found: error
+          include-hidden-files: true
         continue-on-error: true
 
       - name: Delete release branch if deploy failed and fail

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -96,11 +96,10 @@ jobs:
           artifact="${artifactId}-${version}"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo .$artifact/)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
-          mkdir .$artifact
           shopt -s extglob
-          cp target/!(original*.jar) -t .$artifact
+          cp target/!(original*.jar) -t artifact-$artifact
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -96,9 +96,10 @@ jobs:
           artifact="${artifactId}-${version}.zip"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo $artifact)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo $artifact.zip)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE 
-          echo "zip ${artifact} target/* -D -Z deflate -x 'original*.jar'" >> ${GITHUB_ENV}
+          cd target
+          zip ${artifact} * -D -Z deflate -x 'original*.jar'
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -99,7 +99,8 @@ jobs:
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
           mkdir $artifact
-          cp target/* -t $artifact
+          cp target/* -t $artifact || :
+          rm $artifact/original*.jar
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -93,12 +93,14 @@ jobs:
         run: |
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}.zip"
+          artifact="${artifactId}-${version}"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo $artifact)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo .$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
-          zip -j ${artifact} target/* -D -x '*original*.jar'
+          mkdir .$artifact
+          shopt -s extglob
+          cp target/!(original*.jar) -t .$artifact
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -93,13 +93,12 @@ jobs:
         run: |
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}"
+          artifact="${artifactId}-${version}.zip"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo $artifact.zip)" >> ${GITHUB_ENV}
-          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE 
-          cd target
-          zip ${artifact} * -D -Z deflate -x 'original*.jar'
+          echo "artifact-path=$(echo $artifact)" >> ${GITHUB_ENV}
+          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
+          zip -j ${artifact} target/* -D -x '*original*.jar'
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -100,7 +100,7 @@ jobs:
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
-          rm .artifact-$artifact/original*.jar
+          rm .artifact-$artifact/original*.jar || :
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -100,7 +100,6 @@ jobs:
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
           mkdir $artifact
           cp target/* -t $artifact
-          rm $artifact/original*.jar
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}.zip"
+          artifact="${artifactId}-${version}"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
           echo "artifact-path=$(echo $artifact.zip)" >> ${GITHUB_ENV}

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -94,13 +94,14 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}"
-          echo "version=$(echo $version)" >> ${GITHUB_ENV}
-          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
           rm .artifact-$artifact/original*.jar || :
+          echo "version=$(echo $version)" >> ${GITHUB_OUTPUT}
+          echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
+          echo "artifactId=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
+          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -98,9 +98,9 @@ jobs:
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
-          mkdir .artifact-$artifact
-          cp target/* -t .artifact-$artifact
-          rm .artifact-$artifact/original*.jar
+          mkdir $artifact
+          cp target/* -t $artifact
+          rm $artifact/original*.jar
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -111,8 +111,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifactId }}-${{ env.version }}
-          path: ${{ env.artifact-path }}
+          name: ${{ steps.build.outputs.artifact }}
+          path: ${{ steps.build.outputs.artifact-path }}
           include-hidden-files: true
           if-no-files-found: error
 

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -96,10 +96,11 @@ jobs:
           artifact="${artifactId}-${version}"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo artifact-$artifact/)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
-          shopt -s extglob
-          cp target/!(original*.jar) -t artifact-$artifact
+          mkdir .artifact-$artifact
+          cp target/* -t .artifact-$artifact
+          rm .artifact-$artifact/original*.jar
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -98,9 +98,9 @@ jobs:
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
-          mkdir $artifact
-          cp target/* -t $artifact || :
-          rm $artifact/original*.jar
+          mkdir .artifact-$artifact
+          cp target/* -t .artifact-$artifact || :
+          rm .artifact-$artifact/original*.jar
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'
@@ -112,6 +112,8 @@ jobs:
         with:
           name: ${{ env.artifactId }}-${{ env.version }}
           path: ${{ env.artifact-path }}
+          include-hidden-files: true
+          if-no-files-found: error
 
       - name: Check if docs present
         id: docs

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -93,11 +93,12 @@ jobs:
         run: |
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          artifact="${artifactId}-${version}.jar"
+          artifact="${artifactId}-${version}.zip"
           echo "version=$(echo $version)" >> ${GITHUB_ENV}
           echo "artifactId=$(echo $artifactId)" >> ${GITHUB_ENV}
-          echo "artifact-path=$(echo target/$artifact)" >> ${GITHUB_ENV}
+          echo "artifact-path=$(echo $artifact)" >> ${GITHUB_ENV}
           mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE 
+          echo "zip ${artifact} target/* -D -Z deflate -x 'original*.jar'" >> ${GITHUB_ENV}
 
           #  - name: Upload coverage to Codecov
           #    if: steps.build.outcome == 'success'


### PR DESCRIPTION
# Description

Allow for Maven repos using the `maven-app-release.yml`, `maven-app-release-with-docs.yml`, and `maven-app-snapshot.yml` workflows to support outputting multiple files as artifacts and release assets, rather than a single JAR file.

This is done in a backwards-compatible way with repos that expect to output a single JAR. When a maven project is built, it produces a `target/` folder that looks roughly like this:
```
classes/
coverage-reports/
generated-sources/
generated-test-sources/
kotlin-ic/
maven-status/
site/
surefire-reports/
test-classes/
**project-version.jar**
original-project-version.jar
```

Under the old workflows, **project-version.jar** would be identified as the build artifact and attached as a release asset.

With these changes, every file in the top-level of the `target/` directory, ignoring sub-directories, will be added, with the exception of the file that matches the pattern `original-*.jar`.

Maven repos that use these workflows can now include additional artifacts in the release, by configuring the pom/maven plugins to ensure that those files are outputted in the top-level of the `target/` directory alongside **project-version.jar**, like so:

```
classes/
coverage-reports/
generated-sources/
generated-test-sources/
kotlin-ic/
maven-status/
site/
surefire-reports/
test-classes/
**project-version.jar**
original-project-version.jar
**additional-artifact.dll**
**additional-artifact.so**
**another-additional-artifact.conf**
**yet-another-additional-artifact.md**
```

When producing a release using this new workflow, **project-version.jar**, **additional-artifact.dll**, **additional-artifact.so**, **another-additional-artifact.conf** and **yet-another-additional-artifact.md** will all be included as release assets.

# Associated tasks

Needed for https://github.com/zepben/ednar-app-server/pull/376, where a wrapper.conf file needs to be included with future releases of the EDNAR App Server. A similar pattern will be used for other maven projects once this change is merged in.

# Test Steps

To validate this works with multiple artifacts, check out https://github.com/zepben/ednar-app-server/pull/376 and produce a snapshot release using CI to validate that multiple build artifacts are produced.

To validate this is backwards-compatible with repos that are unchanged except for the use of the new workflow, you can see the latest "release" of the EDNAR LDAP Polling service: https://github.com/zepben/ldap-user-polling-service (I will be erasing this release after this branch is merged)

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- ~[ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- ~[ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- ~[ ] I have updated the changelog.~
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Should not be a breaking change - should be backwards-compatible with the previous maven-app-* workflows. Regardless, I have communicated this change on slack.