### PR TITLE
[OPS-299] Fix error 141 in latest_changelog generation

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -140,6 +140,22 @@ jobs:
               exit 1
           fi
 
+      - name: Test changelog format
+        id: changelog
+        shell: bash
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
+
   deploy:
     needs: release-checks
     runs-on: windows-2019
@@ -336,10 +352,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" ${{ inputs.changelog }} | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat ${{ inputs.changelog }} | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -107,6 +107,21 @@ jobs:
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Test changelog format
+        id: changelog
+        shell: bash
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
   deploy:
     needs: release-checks
     runs-on: windows-2019
@@ -240,10 +255,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" ${{ inputs.changelog }} | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat ${{ inputs.changelog }} | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -136,6 +136,20 @@ jobs:
               exit 1
           fi
 
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
 
   build-docs:
     needs: release-checks
@@ -345,13 +359,9 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
-
 
       - name: Create Release and upload assets
         if: success()

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -138,6 +138,7 @@ jobs:
 
       - name: Test changelog format
         id: changelog
+        shell: bash
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -87,8 +87,23 @@ jobs:
           /scripts/release-checks.sh --java --maven pom.xml
           /scripts/finalize-version.sh --java --maven pom.xml changelog.md
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
+
+      - name: Test changelog format
+        id: changelog
+        shell: bash
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
   deploy:
     needs: release-checks
@@ -212,10 +227,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Test changelog format
         id: changelog
+        shell: bash
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -104,7 +104,7 @@ jobs:
           /scripts/release-checks.sh --java --maven pom.xml
           /scripts/finalize-version.sh --java --maven pom.xml changelog.md
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
 
       - name: Check if docs present
@@ -138,6 +138,20 @@ jobs:
               echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
               exit 1
           fi
+
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
   build-docs:
     needs: release-checks
@@ -349,13 +363,9 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
-
 
       - name: Create Release and upload assets
         if: success()

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -82,8 +82,24 @@ jobs:
           /scripts/release-checks.sh --java --maven pom.xml
           /scripts/finalize-version.sh --java --maven pom.xml changelog.md
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          echo "::set-output name=version::$(echo $version)"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
+
+      - name: Test changelog format
+        id: changelog
+        shell: bash
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
 
   deploy:
     needs: release-checks
@@ -208,10 +224,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -46,6 +46,7 @@ jobs:
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
+      version: ${{ steps.check.outputs.version }}
       docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v4
@@ -71,9 +72,12 @@ jobs:
           PATH: ${{ inputs.sourcepath }}
 
       - name: Release checks and update version for release
+        id: check
         run: |
           /scripts/release-checks.sh --js package.json
           /scripts/finalize-version.sh --js package.json changelog.md
+          version=$(jq -r .version package.json)
+          echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Check if docs present
@@ -109,6 +113,19 @@ jobs:
               exit 1
           fi
 
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
   build-docs:
     needs: release-checks
@@ -261,8 +278,8 @@ jobs:
           artifactId=$(jq -r .name package.json)
           artifact="$artifactId-$version.tar.bz2"
           tar jcvf "$artifact" -C dist .
-          echo "::set-output name=version::$(echo $version)"
-          echo "::set-output name=artifact::$(echo $artifact)"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
+          echo "artifact=$artifact" >> "${GITHUB_OUTPUT}"
         continue-on-error: true
 
       - uses: actions/upload-artifact@v4
@@ -301,10 +318,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Test changelog format
         id: changelog
+        shell: bash
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -125,6 +125,7 @@ jobs:
 
       - name: Test changelog format
         id: changelog
+        shell: bash
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -123,6 +123,20 @@ jobs:
               exit 1
           fi
 
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
   python-deps-check:
     needs: release-checks
     runs-on: ubuntu-latest
@@ -345,10 +359,7 @@ jobs:
       - name: Get latest changelog
         id: changelog
         run: |
-          lines=$(egrep -n "## \[[0-9]+\.[0-9]+\.[0-9]+\]" changelog.md | head -2 | cut -f1 -d:)
-          line1=$(echo "$lines" | head -1)
-          line2=$(echo "$lines" | tail -1)
-          cat changelog.md | tail -n +$((line1+1)) | head -n $((line2-line1-1)) > latest_changelog.txt
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
         shell: bash
         continue-on-error: true
 


### PR DESCRIPTION
# Description

We still have a few workflows that sometimes get error 141 in bash when generating the latest_changelog entry. This is caused by a racing condition in bash between the parts of the pipeline, and it's hard to catch.

This patch reworks the functionality to use 1 command in attempt to avoid this error in the future. This way of generating the latest_changelog is already used in `npm-lib` workflows.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.
~- [ ] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Not a breaking change - the functionality fixed is currently broken anyway.