### PR TITLE
[OPS-277] Add script to create branch protection rules for repositories

### DIFF
--- a/misc/repos-config/branch-protection-rules.json
+++ b/misc/repos-config/branch-protection-rules.json
@@ -1,0 +1,60 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 4100649,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    }
+  ],
+  "current_user_can_bypass": "always",
+  "headers": {
+    "X-GitHub-Api-Version": "2022-11-28"
+  }
+}

--- a/misc/repos-config/branch-protection-rules.json
+++ b/misc/repos-config/branch-protection-rules.json
@@ -23,7 +23,7 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "~DEFAULT_BRANCH"
+        "main"
       ]
     }
   },

--- a/misc/repos-config/branch-protection-rules.json
+++ b/misc/repos-config/branch-protection-rules.json
@@ -23,13 +23,16 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "main"
+        "refs/heads/main"
       ]
     }
   },
   "rules": [
     {
       "type": "deletion"
+    },
+    {
+      "type": "update"
     },
     {
       "type": "non_fast_forward"

--- a/misc/repos-config/set-branch-protection-rules.sh
+++ b/misc/repos-config/set-branch-protection-rules.sh
@@ -65,9 +65,7 @@ repos=(
     zepben/sincal-model-refiner
     zepben/ednar-app-server
     zepben/ms-fault-location
-    zepben/web-client-ci-test
     zepben/ednar-customer-scripts
-    zepben/python-lib-ci-test
     zepben/hv-network-tracing
     zepben/edith-sdk
     zepben/lasarus-nrbu-archive-read-only
@@ -90,7 +88,6 @@ repos=(
     zepben/noose
     zepben/pof-historian-service
     zepben/company-website
-    zepben/npm-lib-ci-test
     zepben/eslint-config-ts
     zepben/ednar-dms-agent
     zepben/feeder-load-aggregator

--- a/misc/repos-config/set-branch-protection-rules.sh
+++ b/misc/repos-config/set-branch-protection-rules.sh
@@ -1,0 +1,124 @@
+# GitHub CLI api
+# https://cli.github.com/manual/gh_api
+
+repos=(
+    zepben/zepben.github.io
+    zepben/docusaurus-preset
+    zepben/network-diagnostic-tool
+    zepben/evolve
+    zepben/bitbucket-trigger-pipeline-action
+    zepben/cimdemo
+    zepben/evolve-python-sdk-tests
+    zepben/docusaurus-action
+    zepben/docusaurus-components
+    zepben/clickup-automation
+    zepben/2030-5-model-site
+    zepben/psse-translator
+    zepben/repo-template-css
+    zepben/sincal-to-evolve
+    zepben/load-synthesiser
+    zepben/evolve-azure-templates
+    zepben/python-sdk-demos
+    zepben/jvm-sdk-demos
+    zepben/kotlin-oauth2-server
+    zepben/tas-geojson-transformer
+    zepben/zepben-auth-python
+    zepben/fault-location
+    zepben/osi-pi-agent
+    zepben/python-sdk-examples
+    zepben/bb_model_comparator
+    zepben/network-explorer
+    zepben/ewb-sandbox-demo
+    zepben/zepben-ca
+    zepben/hosting_capacity_analysis
+    zepben/ee-evolve-deployment
+    zepben/evolve-functional-testing
+    zepben/evolve-tutorials
+    zepben/wp-network-extractor
+    zepben/fault-location-trial
+    zepben/datamodel-documentation
+    zepben/synthetic-loads
+    zepben/opendss-ingestor
+    zepben/ewb-data-model-requirements
+    zepben/opendss-exporter
+    zepben/ee_hybrid_premise_ingestor
+    zepben/cim-to-opendss-processor
+    zepben/load-aggregator
+    zepben/how-tos
+    zepben/ea-extractor
+    zepben/lasarus-nr-client
+    zepben/zepben-auth-jvm
+    zepben/sincal-load-allocation
+    zepben/ednar-reporting-service
+    zepben/network-trace-extractor
+    zepben/opendss-scheduler
+    zepben/hosting-capacity-study
+    zepben/sincal-exporter
+    zepben/go-scheduler
+    zepben/csharp-extensions
+    zepben/sincal-model-generator
+    zepben/ausnet-daily-script
+    zepben/sincal-automation-ee
+    zepben/hosting-capacity-intervention-analysis
+    zepben/intellij-idea-settings
+    zepben/interval-data-loader
+    zepben/sincal-model-refiner
+    zepben/ednar-app-server
+    zepben/ms-fault-location
+    zepben/web-client-ci-test
+    zepben/ednar-customer-scripts
+    zepben/python-lib-ci-test
+    zepben/hv-network-tracing
+    zepben/edith-sdk
+    zepben/lasarus-nrbu-archive-read-only
+    zepben/lasarus-server
+    zepben/lasarus-linux-agent
+    zepben/lasarus-ar-client
+    zepben/conductor-code-transfer
+    zepben/lasarus-documentation
+    zepben/smart-load-plugin-setup
+    zepben/evolve-datamodel-site
+    zepben/ewb-load-ui
+    zepben/customer-info
+    zepben/questdb
+    zepben/surf
+    zepben/powerfactory-template-service
+    zepben/hosting-capacity-runner
+    zepben/hosting-capacity-example
+    zepben/pcor-pqv-processor
+    zepben/ednar-cppal-usb-polling-service
+    zepben/noose
+    zepben/pof-historian-service
+    zepben/company-website
+    zepben/npm-lib-ci-test
+    zepben/eslint-config-ts
+    zepben/ednar-dms-agent
+    zepben/feeder-load-aggregator
+    zepben/artificial-load-profiles-generator
+    zepben/spatialeye-extractor
+    zepben/ldap-user-polling-service
+    zepben/aft-account-customizations
+    zepben/aft-account-provisioning-customizations
+    zepben/aft-global-customizations
+    zepben/opendss-debugger
+    zepben/load-clustering
+    zepben/zconf
+    zepben/maven-login
+    zepben/cgmes-importer
+    zepben/opendss-jvm-executor
+    zepben/load-process-cs
+    zepben/ops-lambdas
+    zepben/powercor-ednar-config
+    zepben/load-data-ingestor
+    zepben/platform-workflows
+)
+
+for repo in ${repos[@]}; do
+    echo "Fixing repo permissions: $repo"
+    gh api \
+      --method POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      /repos/$repo/rulesets \
+      --input branch-protection-rules.json
+done


### PR DESCRIPTION
# Description

Adding branch protection via `gh` to a bunch of repositories.

This is just a location for the script, not trying to make it "production-ready"


Tested on `mvn-lib-ci-test`, `mvn-app-ci-test` and `npm-app-ci-test` repositories.