### PR TITLE
[OPS-313] Upload all artefacts for a release

### DIFF
--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -381,7 +381,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            built-artifacts/${{ needs.deploy.outputs.artifact }}
+            built-artifacts/*
         continue-on-error: true
 
       - name: Deploy documentation


### PR DESCRIPTION
# Description

Fix the `create-release` job in the `maven-app-release-with-docs` flow to include all files in the artefact path when uploading files for a release.


# Associated tasks

List any other tasks / PRs that are required to be merged alongside this one (e.g. front end task for back end change or vice versa). If a PR exists, add a link. If not, just add an appropriate note here so reviewers know there is a dependency and will hold off merging until all things are ready.

# Test Steps

Tested in the `mvn-app-ci-test` repository
https://github.com/zepben/mvn-app-ci-test/actions/runs/14234846634/job/39892351237

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).



# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not a breaking change.