### PR TITLE
[OPS-314] Add 'changelog' output parameter to release-checks job

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -74,6 +74,7 @@ jobs:
       version: ${{ steps.check.outputs.version }}
       artifact_id: ${{ steps.check.outputs.artifact_id }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -72,6 +72,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -58,6 +58,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -75,6 +75,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -53,6 +53,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -48,6 +48,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -59,6 +59,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -50,7 +50,6 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -50,6 +50,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We checked the proper format of the changelog in the `release-check` step for most of the repos; however, we did not export the result of that check as an output, so during the release creation, there were no files to add as notes. This change restores the 'changelog' output in the `release-checks` job, passing it along to the `release` step.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the 

This is not a breaking change.