### PR TITLE
[OPS-340] Fix node:20 runner containers

### DIFF
--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add jq tar alpine-conf git openssh curl bash
+          apk add jq tar alpine-conf git openssh curl bash github-cli
 
       - name: Cache nodejs deps
         uses: actions/cache@v4

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        apk add jq tar alpine-conf git curl bash
+        apk add jq tar alpine-conf git curl bash github-cli
 
     - name: Cache nodejs deps
       uses: actions/cache@v4

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add jq tar alpine-conf git curl bash
+          apk add jq tar alpine-conf git curl bash github-cli
 
       - name: Cache nodejs deps
         uses: actions/cache@v4

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        apk add jq tar alpine-conf git curl bash
+        apk add jq tar alpine-conf git curl bash github-cli
 
     - name: Cache nodejs deps
       uses: actions/cache@v4


### PR DESCRIPTION
# Description

The `node:20` runner containers do not have `gh` installed, this change fixes that.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not a breaking change.