### PR TITLE
[OPS-355] Split repo check and build workflows for csharp

### DIFF
--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -63,12 +63,74 @@ on:
         value: ${{ jobs.build.outputs.version }}
 
 jobs:
+  checks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    outputs: 
+      docs-present: ${{ steps.docs.outputs.present }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Cache licence-check
+        uses: actions/cache@v4
+        with:
+          path: /lc
+          key: lcc
+
+      - name: Check licence
+        uses: zepben/licence-check-action@main
+        with:
+          LC_URL: ${{ secrets.LC_URL }}
+          PATH: ${{ inputs.sourcepath }}
+
+      - name: Check if docs present
+        id: docs
+        shell: bash
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/docs' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
   build:
     runs-on: windows-2019
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     outputs:
-      docs-present: ${{ steps.docs.outputs.present }}
       version: ${{ steps.update-info-version.outputs.info_version }}
     steps:
     - name: Checkout Code
@@ -79,18 +141,6 @@ jobs:
         dname=$(echo ${{github.repository}} | cut -d'/' -f2)
         git config --global --add safe.directory /__w/$dname/$dname
       shell: sh
-
-    - name: Cache licence-check
-      uses: actions/cache@v4
-      with:
-        path: /lc
-        key: lcc
-
-    - name: Check licence
-      uses: zepben/licence-check-action@main
-      with:
-        LC_URL: ${{ secrets.LC_URL }}
-        PATH: ${{ inputs.sourcepath }}
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
@@ -146,44 +196,6 @@ jobs:
       with:
         name: ${{ env.artifact_id }}-${{ env.info_version }}
         path: ${{ env.artifact_id }}/bin/Release/
-
-    - name: Check if docs present
-      id: docs
-      run: |
-        if [ -d docs ]; then
-          echo "Docs folder found, will run the build-docs job"
-          echo "present=yes" >> "${GITHUB_OUTPUT}"
-          echo "present=yes" >> "${GITHUB_ENV}"
-        else
-          echo "Docs folder not found, will skip the build-docs"
-        fi
-
-    - name: Work around git permission issue
-      run: |
-        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-        git config --global --add safe.directory /__w/$dname/$dname
-      shell: sh
-
-    - name: Check doc build artifacts are ignored
-      if: ${{ env.present == 'yes' }}
-      shell: sh {0}
-      run: |
-        # Make sure directories are properly ignored
-        # docs/node_modules
-        git check-ignore -q docs/node_modules
-        if [ $? != 0 ]; then
-            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-            exit 1
-        fi
-
-        # docs/build
-        git check-ignore -q docs/build
-        if [ $? != 0 ]; then
-            echo "ERROR! Make sure to add 'docs/build' to .gitignore"
-            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-            exit 1
-        fi
 
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -39,10 +39,72 @@ on:
         required: false
  
 jobs:
-  build-and-test:
-    runs-on: windows-2019
+  checks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
     outputs: 
       docs-present: ${{ steps.docs.outputs.present }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - name: Cache licence-check
+        uses: actions/cache@v4
+        with:
+          path: /lc
+          key: lcc
+
+      - name: Check licence
+        uses: zepben/licence-check-action@main
+        with:
+          LC_URL: ${{ secrets.LC_URL }}
+          PATH: ${{ inputs.sourcepath }}
+
+      - name: Check if docs present
+        id: docs
+        shell: bash
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/docs' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
+  build-and-test:
+    needs: checks
+    runs-on: windows-2019
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -58,18 +120,6 @@ jobs:
         git config --global --add safe.directory /__w/$dname/$dname
       shell: sh
 
-    - name: Cache licence-check
-      uses: actions/cache@v4
-      with:
-        path: /lc
-        key: lcc
-
-    - name: Check licence
-      uses: zepben/licence-check-action@main
-      with:
-        LC_URL: ${{ secrets.LC_URL }}
-        PATH: ${{ inputs.sourcepath }}
-    
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
      
@@ -93,49 +143,10 @@ jobs:
       if: ${{ inputs.test_files != '' }}
       run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ inputs.platform }}
 
-    - name: Check if docs present
-      id: docs
-      shell: bash
-      run: |
-        if [ -d docs ]; then
-          echo "Docs folder found, will run the build-docs job"
-          echo "present=yes" >> "${GITHUB_OUTPUT}"
-          echo "present=yes" >> "${GITHUB_ENV}"
-        else
-          echo "Docs folder not found, will skip the build-docs"
-        fi
-
-    - name: Work around git permission issue
-      run: |
-        dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-        git config --global --add safe.directory /__w/$dname/$dname
-      shell: sh
-
-    - name: Check doc build artifacts are ignored
-      if: ${{ env.present == 'yes' }}
-      shell: sh {0}
-      run: |
-        # Make sure directories are properly ignored
-        # docs/node_modules
-        git check-ignore -q docs/node_modules 
-        if [ $? != 0 ]; then
-            echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-            echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-            exit 1
-        fi
-
-        # docs/build
-        git check-ignore -q docs/build 
-        if [ $? != 0 ]; then
-            echo "ERROR! Make sure to add 'docs/docs' to .gitignore"
-            echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-            exit 1
-        fi
-
   build-docs:
     runs-on: ubuntu-latest
-    needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.docs-present == 'yes' }}
+    needs: checks
+    if: ${{ needs.checks.outputs.docs-present == 'yes' }}
     container: node:20-alpine
     steps:
 


### PR DESCRIPTION
At the moment we have a couple of C#-related workflows where the repo checks (licence check, docs presence and whether some build docusaurus files are added to .gitignore) are run within the build job, which runs the Windows container. This host cannot run these checks.

This change splits  the repo checks out into a separate job, and keeps Windows host for building and testing C# only.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).


# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members.

Not  a breaking change.