### PR TITLE
Improve debug messages when we clear the release branch

### DIFF
--- a/.github/workflows/csharp-app-release-with-docs.yml
+++ b/.github/workflows/csharp-app-release-with-docs.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -219,11 +219,11 @@ jobs:
           path: ${{ steps.upload_path.outputs.path }}
           if-no-files-found: error
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in one of the steps above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 
@@ -325,7 +325,7 @@ jobs:
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in merging the branch. release branch was deleted."
+          echo "There was an error in merging the branch. Release branch was deleted."
           exit 1
         shell: bash
 

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -184,11 +184,11 @@ jobs:
           path: ${{ steps.upload_path.outputs.path }}
           if-no-files-found: error
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in one of the steps above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 

--- a/.github/workflows/maven-app-release-with-docs.yml
+++ b/.github/workflows/maven-app-release-with-docs.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -309,11 +309,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn package command above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 
@@ -352,7 +352,7 @@ jobs:
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in merging the branch. release branch was deleted."
+          echo "There was an error in merging the branch. Release branch was deleted."
           exit 1
         shell: bash
 

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -176,11 +176,11 @@ jobs:
           include-hidden-files: true
         continue-on-error: true
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn deploy command above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 

--- a/.github/workflows/maven-lib-release-with-docs.yml
+++ b/.github/workflows/maven-lib-release-with-docs.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -308,11 +308,11 @@ jobs:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn deploy command above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -168,11 +168,11 @@ jobs:
           path: ${{ steps.build.outputs.artifact-path }}
           if-no-files-found: error
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn deploy command above."
+          echo "The deployment step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 
@@ -211,7 +211,7 @@ jobs:
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in merging the branch. release branch was deleted."
+          echo "There was an error in merging the branch. Release branch was deleted."
           exit 1
         shell: bash
 

--- a/.github/workflows/npm-app-release-with-docs.yml
+++ b/.github/workflows/npm-app-release-with-docs.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1
@@ -289,11 +289,11 @@ jobs:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact }}
 
-      - name: Fail build
+      - name: Build failed so fail the workflow
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the npm package command above."
+          echo "The build step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: sh
 
@@ -342,7 +342,7 @@ jobs:
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in merging the branch. release branch was deleted."
+          echo "There was an error in merging the branch. Release branch was deleted."
           exit 1
         shell: bash
 

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             exit 1
           fi
@@ -251,11 +251,11 @@ jobs:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact }}
 
-      - name: Fail build
+      - name: Build failed so fail the workflow
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the npm package command above."
+          echo "The build step has failed; check the step **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: sh
 

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
           if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch and failing."
             git push origin -d release
             # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
             exit 1

--- a/.github/workflows/python-lib-release-with-docs.yml
+++ b/.github/workflows/python-lib-release-with-docs.yml
@@ -304,11 +304,11 @@ jobs:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
 
-      - name: Delete release branch if deploy failed and fail
-        if: steps.build.outcome == 'failure'
+      - name: If deploy above failed, delete release branch and fail
+        if: steps.build.outcome == 'failure' 
         run: |
           git push origin -d release
-          echo "There was an error in the python build and publish commands above."
+          echo "There was an error in the python build and publish commands **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -156,11 +156,11 @@ jobs:
           path: ${{ steps.build.outputs.artifact-path }}
           if-no-files-found: error
 
-      - name: Delete release branch if deploy failed and fail
+      - name: If deploy above failed, delete release branch and fail
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the python build and publish commands above."
+          echo "There was an error in the python build and publish commands **above**. We've deleted the `release` branch to make it easier to run again when ready."
           exit 1
         shell: bash
 


### PR DESCRIPTION
# Description

Improve debug messages when we clear the release branch

- Improve the name of the job when we clear the `release` branch, so that it's more clear that something else caused an error, not the `git push -d release` command.
- Also clarify the error message itself, pointing to a previous step to look for error.