### PR TITLE
[OPS-401] Support optional push to Nexus

### DIFF
--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: true
+      nexus-name:
+        description: The "project" name for an additional push to the internal Nexus docker container 
+        required: false
+        type: string
+        default: ''
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -121,6 +126,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.CI_GITHUB_TOKEN }}
 
+      - name: Login to Nexus Container Registry
+        if: ${{ inputs.nexus-name != '' }} 
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NEXUS_DOCKER_REPO }} 
+          username: ${{ github.actor }}
+          password: ${{ secrets.CI_GITHUB_TOKEN }}
+
       # Priority sorting determines the tag used in the OCI label
       # The current order preferences the version, then commit, then any special tags
       # We always push a commit based tag
@@ -128,7 +141,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_URL }}
+          images: |
+            name=${{ env.REGISTRY_URL }},enable=true
+            name=${{ secrets.NEXUS_DOCKER_REPO }}/${{ inputs.nexus-name }},enable=${{ inputs.nexus-name != '' }}
           labels: |
             org.opencontainers.image.vendor=Zepben
           tags: |


### PR DESCRIPTION
# Description

Add an option in docker image builder flow to also push to Nexus container registry.

This will allow dependent projects to provide an additional parameter to push images to Nexus.
