### PR TITLE
[OPS-407] Add a check to maven PR builds so that incorrect SNAPSHOT naming usage can't be merged

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -59,6 +59,15 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
+      - name: Check the snapshot version
+        shell: bash
+        run: |
+          xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version" | grep SNAPSHOT
+          if [ $? == 0 ]; then
+            echo "This project has a '-SNAPSHOT' in its version number. Replace it with 'b'" 
+            exit 1
+          fi
+
       - name: Cache maven deps
         uses: actions/cache@v4
         with:

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version" | grep SNAPSHOT
-          if [ $? == 0 ]; then
+          if [ $? = 0 ]; then
             echo "This project has a '-SNAPSHOT' in its version number. Replace it with 'b'" 
             exit 1
           fi


### PR DESCRIPTION
# Description

Add a check to maven PR builds so that incorrect SNAPSHOT naming usage can't be merged.


# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).


# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

A slighly breaking change - projects that use `-SNAPSHOT` in their version will fail the maven build. They will need to be updated to use `b` instead.