### PR TITLE
Swallow errors and handle them in the job step

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check the snapshot version
         shell: bash {0}
         run: |
-          version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version" | grep SNAPSHOT)
+          xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version" | grep SNAPSHOT
           if [ $? = 0 ]; then
             echo "This project has a '-SNAPSHOT' in its version number. Replace it with 'b'" 
             exit 1


### PR DESCRIPTION
# Description

Swallow errors when checking for Maven snapshot version and handle them in the job step.