### PR TITLE
"release-with-docs" flows are going away. Enough is enough

### DIFF
--- a/.github/workflows/csharp-app-old-release.yml
+++ b/.github/workflows/csharp-app-old-release.yml
@@ -1,4 +1,4 @@
-name: CSharp App Release With Docs
+name: CSharp App Release
 
 on:
   workflow_call:
@@ -73,8 +73,6 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       artifact_id: ${{ steps.check.outputs.artifact_id }}
-      docs-present: ${{ steps.docs.outputs.present }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,38 +107,6 @@ jobs:
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Check if docs present
-        id: docs
-        run: |
-          if [ -d docs ]; then
-            echo "Docs folder found, will run the build-docs job"
-            echo "present=yes" >> "${GITHUB_OUTPUT}"
-            echo "present=yes" >> "${GITHUB_ENV}"
-          else
-            echo "Docs folder not found, will skip the build-docs"
-          fi
-
-      - name: Check doc build artifacts are ignored
-        if: ${{ env.present == 'yes' }}
-        shell: sh {0}
-        run: |
-          # Make sure directories are properly ignored
-          # docs/node_modules
-          git check-ignore -q docs/node_modules
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              exit 1
-          fi
-
-          # docs/build
-          git check-ignore -q docs/build
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-              exit 1
-          fi
-
       - name: Test changelog format
         id: changelog
         shell: bash
@@ -155,7 +121,6 @@ jobs:
           # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
-
 
   deploy:
     needs: release-checks
@@ -227,71 +192,8 @@ jobs:
           exit 1
         shell: bash
 
-  build-docs:
-    needs: release-checks
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
-    outputs:
-      artifact: docs
-    container: node:20-alpine
-    steps:
-      - name: Install Git
-        run: |
-          apk add git zip
-
-      - name: Work around git permission issue
-        run: |
-          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-          git config --global --add safe.directory /__w/$dname/$dname
-        shell: sh
-
-      - uses: actions/checkout@v4
-
-      - name: Checkout release branch
-        run: |
-          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --all
-          git checkout release
-        shell: sh
-
-      - name: Cache nodejs deps
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm
-
-      - name: Build docusaurus
-        id: build
-        uses: zepben/docusaurus-action@main
-        with:
-          VERSION: ${{ needs.release-checks.outputs.version }}
-          NPM_REPO: ${{ secrets.NPM_REPO }}
-          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs/build
-          zip -r ../../docs.zip .
-        shell: sh
-
-      - uses: actions/upload-artifact@v4
-        if: steps.build.outcome == 'success'
-        with:
-          name: docs.zip
-          path: docs.zip
-
-      - name: Fail build
-        if: steps.build.outcome == 'failure'
-        run: |
-          git push origin -d release
-          echo "There was an error in the docusaurus build above."
-          exit 1
-        shell: sh
-
-
   create-release:
-    needs: [deploy, release-checks, build-docs]
+    needs: [deploy, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -330,7 +232,7 @@ jobs:
         shell: bash
 
       - name: Download binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.release-checks.outputs.artifact_id }}
           path: built-artifacts
@@ -368,9 +270,9 @@ jobs:
           body_path: latest_changelog.txt
           draft: false
           prerelease: false
-          files: |
-            built-artifacts/${{ needs.release-checks.outputs.artifact_id }}.zip
+          files: built-artifacts/${{ needs.release-checks.outputs.artifact_id }}.zip
         continue-on-error: true
+
 
   update-version:
     needs: [create-release]

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -1,4 +1,4 @@
-name: CSharp App Release
+name: CSharp App Release With Docs
 
 on:
   workflow_call:
@@ -73,6 +73,8 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       artifact_id: ${{ steps.check.outputs.artifact_id }}
+      docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,6 +109,38 @@ jobs:
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
       - name: Test changelog format
         id: changelog
         shell: bash
@@ -121,6 +155,7 @@ jobs:
           # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
 
   deploy:
     needs: release-checks
@@ -192,8 +227,71 @@ jobs:
           exit 1
         shell: bash
 
+  build-docs:
+    needs: release-checks
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact: docs
+    container: node:20-alpine
+    steps:
+      - name: Install Git
+        run: |
+          apk add git zip
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - uses: actions/checkout@v4
+
+      - name: Checkout release branch
+        run: |
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --all
+          git checkout release
+        shell: sh
+
+      - name: Cache nodejs deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          VERSION: ${{ needs.release-checks.outputs.version }}
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: sh
+
+      - uses: actions/upload-artifact@v4
+        if: steps.build.outcome == 'success'
+        with:
+          name: docs.zip
+          path: docs.zip
+
+      - name: Fail build
+        if: steps.build.outcome == 'failure'
+        run: |
+          git push origin -d release
+          echo "There was an error in the docusaurus build above."
+          exit 1
+        shell: sh
+
+
   create-release:
-    needs: [deploy, release-checks]
+    needs: [deploy, release-checks, build-docs]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -270,9 +368,9 @@ jobs:
           body_path: latest_changelog.txt
           draft: false
           prerelease: false
-          files: built-artifacts/${{ needs.release-checks.outputs.artifact_id }}.zip
+          files: |
+            built-artifacts/${{ needs.release-checks.outputs.artifact_id }}.zip
         continue-on-error: true
-
 
   update-version:
     needs: [create-release]

--- a/.github/workflows/maven-app-old-release.yml
+++ b/.github/workflows/maven-app-old-release.yml
@@ -1,17 +1,12 @@
 # Note: default release notes file is docs/release.md.
-name: Maven App Release + Docs
+name: Maven App Release
 
-on: 
+on:
   workflow_call:
     inputs:
-      product-key:
-        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: false
-        default: "productkeynotprovided"
-        type: string
       private:
         description: 'Calling workflow from a private repo'
-        required: true
+        required: false
         type: boolean
         default: true
       sourcepath:
@@ -19,12 +14,6 @@ on:
         required: false
         type: string
         default: "src"
-
-    outputs:
-      version:
-        description: "The current released version."
-        value: ${{ jobs.release-checks.outputs.version }}
-
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -32,7 +21,7 @@ on:
         required: true
       NEXUS_USERNAME:
         required: true
-      NEXUS_PASSWORD: 
+      NEXUS_PASSWORD:
         required: true
       NEXUS_SIGNATURE:
         required: true
@@ -44,17 +33,14 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      NPM_REPO:
-        required: true
-      DOCS_REPO:
-        required: true
-      DOCS_REPO_EVOLVE_WORKFLOW:
-        required: true
-      LC_URL: 
+      LC_URL:
         required: false
 
 
-
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
@@ -65,13 +51,13 @@ jobs:
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
       NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
       NEXUS_MAVEN_SNAPSHOT: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
@@ -102,40 +88,8 @@ jobs:
           /scripts/release-checks.sh --java --maven pom.xml
           /scripts/finalize-version.sh --java --maven pom.xml changelog.md
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
-          echo "version=$(echo $version)" >> "${GITHUB_OUTPUT}"
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
-
-      - name: Check if docs present
-        id: docs
-        run: |
-          if [ -d docs ]; then
-            echo "Docs folder found, will run the build-docs job"
-            echo "present=yes" >> "${GITHUB_OUTPUT}"
-            echo "present=yes" >> "${GITHUB_ENV}"
-          else
-            echo "Docs folder not found, will skip the build-docs"
-          fi
-
-      - name: Check doc build artifacts are ignored
-        if: ${{ env.present == 'yes' }}
-        shell: sh {0}
-        run: |
-          # Make sure directories are properly ignored
-          # docs/node_modules
-          git check-ignore -q docs/node_modules 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              exit 1
-          fi
-
-          # docs/build
-          git check-ignore -q docs/build 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-              exit 1
-          fi
 
       - name: Test changelog format
         id: changelog
@@ -152,108 +106,12 @@ jobs:
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
-
-  build-docs:
+  deploy:
     needs: release-checks
     runs-on: ubuntu-latest
-    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
-    outputs:
-      artifact: docs
-      product-key: ${{ steps.docs-component.outputs.name }}
-      product-repo: ${{ steps.docs-component.outputs.repo }}
-    container: node:20-alpine
-    steps:
-      - name: Install Git
-        run: |
-          apk add git zip
-
-      - name: Work around git permission issue
-        run: |
-          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-          git config --global --add safe.directory /__w/$dname/$dname
-        shell: sh
-
-      - uses: actions/checkout@v4
-
-      - name: Checkout release branch
-        run: |
-          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --all
-          git checkout release
-        shell: sh
-
-      - name: Cache nodejs deps
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm
-
-      - name: Build docusaurus
-        id: build
-        uses: zepben/docusaurus-action@main
-        with:
-          VERSION: ${{ needs.release-checks.outputs.version }}
-          NPM_REPO: ${{ secrets.NPM_REPO }}
-          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs/build
-          zip -r ../../docs.zip .
-        shell: sh
-
-      - uses: actions/upload-artifact@v4
-        if: steps.build.outcome == 'success'
-        with:
-          name: docs.zip
-          path: docs.zip
-          if-no-files-found: error
-
-      - name: Fail build
-        if: steps.build.outcome == 'failure'
-        run: |
-          git push origin -d release
-          echo "There was an error in the docusaurus build above."
-          exit 1
-        shell: sh
-
-      - name: Fetch the document component name
-        id: docs-component
-        shell: sh {0}
-        run: |
-            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
-            # if product key is supplied
-            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
-              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
-            else
-              # This is just so we know that we can parse the docs component properly
-              if [ -f docs/docusaurus.config.js ]; then
-                # Parse out the baseUrl from the docusaurus configuration.
-                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
-                # Find the component name
-                doc_comp=${baseurl##*/}
-                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
-              else
-                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
-                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
-                  exit 1
-              fi
-            fi
-
-  deploy:
-    needs: [release-checks, build-docs]
-    runs-on: ubuntu-latest
-    container: zepben/pipeline-java-ewb
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
-      artifact-id: ${{ steps.build.outputs.artifact-id }}
-      version: ${{ steps.build.outputs.version }}
-    env:
-      NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
-      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
+    container: zepben/pipeline-java-ewb
     steps:
       - name: Work around git permission issue
         run: |
@@ -282,7 +140,7 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}"
-          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
+          mvn clean package -B -f pom.xml -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dnexus.signature=$NEXUS_SIGNATURE -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
           rm .artifact-$artifact/original*.jar || :
@@ -290,13 +148,21 @@ jobs:
           echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
           echo "artifact-id=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
+
         shell: bash
+        env:
+          NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
+          NEXUS_RELEASE_URL: ${{ secrets.NEXUS_MAVEN_RELEASE }}
+          NEXUS_SNAPSHOT_URL: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
         continue-on-error: true
 
       - name: Upload coverage to Codecov
         if: steps.build.outcome == 'success'
         uses: codecov/codecov-action@v4
-        with: 
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
@@ -306,19 +172,20 @@ jobs:
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
-          include-hidden-files: true
           if-no-files-found: error
+          include-hidden-files: true
+        continue-on-error: true
 
       - name: Delete release branch if deploy failed and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn package command above."
+          echo "There was an error in the mvn deploy command above."
           exit 1
         shell: bash
 
   create-release:
-    needs: [deploy, build-docs, release-checks]
+    needs: [deploy, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -344,11 +211,11 @@ jobs:
           git push origin ${GITHUB_REF/refs\/heads\//}
           git tag "v${{ needs.release-checks.outputs.version }}"
           git push --tags
-          echo "tag=$(echo v${{ needs.release-checks.outputs.version }})" >> "${GITHUB_OUTPUT}"
+          echo "::set-output name=tag::$(echo v${{ needs.release-checks.outputs.version }})"
         shell: bash
         continue-on-error: true
 
-      - name: Delete release branch if merge failed and fail
+      - name: Fail if any previous step failed
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
@@ -359,8 +226,8 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.deploy.outputs.artifact }}
           path: built-artifacts
+          merge-multiple: true
         continue-on-error: true
 
       - name: Get latest changelog
@@ -385,20 +252,6 @@ jobs:
             built-artifacts/*
         continue-on-error: true
 
-      - name: Deploy documentation
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          repository: ${{ secrets.DOCS_REPO }}
-          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
-        continue-on-error: true
-
-  # call-build-container:
-  #   needs: [build-artifact, create-release]
-  #   uses: zepben/energy-workbench-server/.github/workflows/build-release-container.yaml@main
-  #   with:
-  #     ewbRelease: ${{ needs.build-artifact.outputs.version }}
 
   update-version:
     needs: [create-release]
@@ -427,5 +280,5 @@ jobs:
 
       - name: Update to next minor version
         run: |
-          /scripts/update-version.sh --java --maven --release pom.xml changelog.md
+          /scripts/update-version.sh --java --grow-changelog --maven --release pom.xml changelog.md
         shell: bash

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -1,9 +1,14 @@
 # Note: default release notes file is docs/release.md.
-name: Maven App Release
+name: Maven App Release + Docs
 
-on:
+on: 
   workflow_call:
     inputs:
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: false
+        default: "productkeynotprovided"
+        type: string
       private:
         description: 'Calling workflow from a private repo'
         required: false
@@ -14,6 +19,12 @@ on:
         required: false
         type: string
         default: "src"
+
+    outputs:
+      version:
+        description: "The current released version."
+        value: ${{ jobs.release-checks.outputs.version }}
+
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -33,7 +44,13 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL:
+      NPM_REPO:
+        required: true
+      DOCS_REPO:
+        required: true
+      DOCS_REPO_EVOLVE_WORKFLOW:
+        required: true
+      LC_URL: 
         required: false
 
 
@@ -51,13 +68,13 @@ jobs:
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
       NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
       NEXUS_MAVEN_SNAPSHOT: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
@@ -91,6 +108,38 @@ jobs:
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
       - name: Test changelog format
         id: changelog
         shell: bash
@@ -106,12 +155,108 @@ jobs:
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
-  deploy:
+
+  build-docs:
     needs: release-checks
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
+    container: node:20-alpine
+    steps:
+      - name: Install Git
+        run: |
+          apk add git zip
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - uses: actions/checkout@v4
+
+      - name: Checkout release branch
+        run: |
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --all
+          git checkout release
+        shell: sh
+
+      - name: Cache nodejs deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          VERSION: ${{ needs.release-checks.outputs.version }}
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: sh
+
+      - uses: actions/upload-artifact@v4
+        if: steps.build.outcome == 'success'
+        with:
+          name: docs.zip
+          path: docs.zip
+          if-no-files-found: error
+
+      - name: Fail build
+        if: steps.build.outcome == 'failure'
+        run: |
+          git push origin -d release
+          echo "There was an error in the docusaurus build above."
+          exit 1
+        shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
+  deploy:
+    needs: [release-checks, build-docs]
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-java-ewb
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
-    container: zepben/pipeline-java-ewb
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
+      version: ${{ steps.build.outputs.version }}
+    env:
+      NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
+      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
     steps:
       - name: Work around git permission issue
         run: |
@@ -140,7 +285,7 @@ jobs:
           artifactId=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           artifact="${artifactId}-${version}"
-          mvn clean package -B -f pom.xml -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dnexus.signature=$NEXUS_SIGNATURE -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
+          mvn clean package -B -f pom.xml -P release -Dgpg.key.id=$GPG_KEY_ID -Dgpg.key.password=$GPG_KEY_PASSWORD -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dnexus.signature=$NEXUS_SIGNATURE
           mkdir .artifact-$artifact
           cp target/* -t .artifact-$artifact || :
           rm .artifact-$artifact/original*.jar || :
@@ -148,15 +293,7 @@ jobs:
           echo "artifact=$(echo $artifact)" >> ${GITHUB_OUTPUT}
           echo "artifact-id=$(echo $artifactId)" >> ${GITHUB_OUTPUT}
           echo "artifact-path=$(echo .artifact-$artifact/)" >> ${GITHUB_OUTPUT}
-
         shell: bash
-        env:
-          NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
-          NEXUS_RELEASE_URL: ${{ secrets.NEXUS_MAVEN_RELEASE }}
-          NEXUS_SNAPSHOT_URL: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
         continue-on-error: true
 
       - name: Upload coverage to Codecov
@@ -172,20 +309,19 @@ jobs:
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
-          if-no-files-found: error
           include-hidden-files: true
-        continue-on-error: true
+          if-no-files-found: error
 
       - name: Delete release branch if deploy failed and fail
         if: steps.build.outcome == 'failure' || steps.upload.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn deploy command above."
+          echo "There was an error in the mvn package command above."
           exit 1
         shell: bash
 
   create-release:
-    needs: [deploy, release-checks]
+    needs: [deploy, build-docs, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -211,11 +347,11 @@ jobs:
           git push origin ${GITHUB_REF/refs\/heads\//}
           git tag "v${{ needs.release-checks.outputs.version }}"
           git push --tags
-          echo "::set-output name=tag::$(echo v${{ needs.release-checks.outputs.version }})"
+          echo "tag=v${{ needs.release-checks.outputs.version }}" >> "${GITHUB_OUTPUT}"
         shell: bash
         continue-on-error: true
 
-      - name: Fail if any previous step failed
+      - name: Delete release branch if merge failed and fail the flow
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
@@ -226,6 +362,7 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
+          name: ${{ needs.deploy.outputs.artifact }}
           path: built-artifacts
           merge-multiple: true
         continue-on-error: true
@@ -252,6 +389,14 @@ jobs:
             built-artifacts/*
         continue-on-error: true
 
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
+        continue-on-error: true
 
   update-version:
     needs: [create-release]

--- a/.github/workflows/maven-lib-old-release.yml
+++ b/.github/workflows/maven-lib-old-release.yml
@@ -1,17 +1,12 @@
 # Note: default release notes file is docs/release.md.
-name: Maven Library Release + Docs
+name: Maven Library Release
 
 on: 
   workflow_call:
     inputs:
-      product-key:
-        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: false
-        default: "productkeynotprovided"
-        type: string
       private:
         description: 'Calling workflow from a private repo'
-        required: false
+        required: true
         type: boolean
         default: true
       sourcepath:
@@ -19,7 +14,6 @@ on:
         required: false
         type: string
         default: "src"
-
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -29,6 +23,8 @@ on:
         required: true
       NEXUS_PASSWORD: 
         required: true
+      NEXUS_SIGNATURE:
+        required: true
       NEXUS_MAVEN_SNAPSHOT:
         required: true
       NEXUS_MAVEN_RELEASE:
@@ -37,26 +33,8 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      LC_URL:
+      LC_URL: 
         required: false
-      ZEPBEN_GPG_KEY:
-        required: false
-      MAVEN_CENTRAL_USERNAME:
-        required: false
-      MAVEN_CENTRAL_PASSWORD:
-        required: false
-      GPG_KEY_ID:
-        required: false
-      GPG_KEY_PASSWORD:
-        required: false
-      NPM_REPO:
-        required: true
-      DOCS_REPO:
-        required: true
-      DOCS_REPO_EVOLVE_WORKFLOW:
-        required: true
-
-
 
 jobs:
   release-checks:
@@ -68,13 +46,13 @@ jobs:
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
       NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
       NEXUS_MAVEN_SNAPSHOT: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +76,7 @@ jobs:
         with:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
-
+       
       - name: Release checks and update version for release
         id: check
         run: |
@@ -107,38 +85,6 @@ jobs:
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
-
-      - name: Check if docs present
-        id: docs
-        run: |
-          if [ -d docs ]; then
-            echo "Docs folder found, will run the build-docs job"
-            echo "present=yes" >> "${GITHUB_OUTPUT}"
-            echo "present=yes" >> "${GITHUB_ENV}"
-          else
-            echo "Docs folder not found, will skip the build-docs"
-          fi
-
-      - name: Check doc build artifacts are ignored
-        if: ${{ env.present == 'yes' }}
-        shell: sh {0}
-        run: |
-          # Make sure directories are properly ignored
-          # docs/node_modules
-          git check-ignore -q docs/node_modules 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              exit 1
-          fi
-
-          # docs/build
-          git check-ignore -q docs/build 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-              exit 1
-          fi
 
       - name: Test changelog format
         id: changelog
@@ -155,96 +101,9 @@ jobs:
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
-  build-docs:
-    needs: release-checks
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
-    outputs:
-      artifact: docs
-      product-key: ${{ steps.docs-component.outputs.name }}
-      product-repo: ${{ steps.docs-component.outputs.repo }}
-    container: node:20-alpine
-    steps:
-      - name: Install Git
-        run: |
-          apk add git zip
-
-      - name: Work around git permission issue
-        run: |
-          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-          git config --global --add safe.directory /__w/$dname/$dname
-        shell: sh
-
-      - uses: actions/checkout@v4
-
-      - name: Checkout release branch
-        run: |
-          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --all
-          git checkout release
-        shell: sh
-
-      - name: Cache nodejs deps
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm
-
-      - name: Build docusaurus
-        id: build
-        uses: zepben/docusaurus-action@main
-        with:
-          VERSION: ${{ needs.release-checks.outputs.version }}
-          NPM_REPO: ${{ secrets.NPM_REPO }}
-          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs/build
-          zip -r ../../docs.zip .
-        shell: sh
-
-      - uses: actions/upload-artifact@v4
-        if: steps.build.outcome == 'success'
-        with:
-          name: docs.zip
-          path: docs.zip
-          if-no-files-found: error
-
-      - name: Fail build
-        if: steps.build.outcome == 'failure'
-        run: |
-          git push origin -d release
-          echo "There was an error in the docusaurus build above."
-          exit 1
-        shell: sh
-
-      - name: Fetch the document component name
-        id: docs-component
-        shell: sh {0}
-        run: |
-            # if product key is supplied
-            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
-              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
-            else
-              # This is just so we know that we can parse the docs component properly
-              if [ -f docs/docusaurus.config.js ]; then
-                # Parse out the baseUrl from the docusaurus configuration.
-                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
-                # Find the component name
-                doc_comp=${baseurl##*/}
-                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
-              else
-                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
-                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
-                  exit 1
-              fi
-            fi
-
 
   deploy:
-    needs: [release-checks, build-docs]
+    needs: release-checks
     runs-on: ubuntu-latest
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
@@ -298,7 +157,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: steps.build.outcome == 'success'
         uses: codecov/codecov-action@v4
-        with: 
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
@@ -307,6 +166,7 @@ jobs:
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
+          if-no-files-found: error
 
       - name: Delete release branch if deploy failed and fail
         if: steps.build.outcome == 'failure'
@@ -317,7 +177,7 @@ jobs:
         shell: bash
 
   create-release:
-    needs: [deploy, build-docs, release-checks]
+    needs: [deploy, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -347,7 +207,7 @@ jobs:
         shell: bash
         continue-on-error: true
 
-      - name: Delete release branch if merge failed and fail
+      - name: Fail if any previous step failed
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
@@ -384,14 +244,6 @@ jobs:
             built-artifacts/${{ needs.deploy.outputs.artifact }}
         continue-on-error: true
 
-      - name: Deploy documentation
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          repository: ${{ secrets.DOCS_REPO }}
-          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
-        continue-on-error: true
 
   update-version:
     needs: [create-release]
@@ -420,5 +272,5 @@ jobs:
 
       - name: Update to next minor version
         run: |
-          /scripts/update-version.sh --java --maven --release pom.xml changelog.md
+          /scripts/update-version.sh --java --grow-changelog --maven --release pom.xml changelog.md
         shell: bash

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -1,12 +1,17 @@
 # Note: default release notes file is docs/release.md.
-name: Maven Library Release
+name: Maven Library Release + Docs
 
 on: 
   workflow_call:
     inputs:
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: false
+        default: "productkeynotprovided"
+        type: string
       private:
         description: 'Calling workflow from a private repo'
-        required: true
+        required: false
         type: boolean
         default: true
       sourcepath:
@@ -14,6 +19,7 @@ on:
         required: false
         type: string
         default: "src"
+
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -35,6 +41,24 @@ on:
         required: false
       LC_URL: 
         required: false
+      ZEPBEN_GPG_KEY:
+        required: false
+      MAVEN_CENTRAL_USERNAME:
+        required: false
+      MAVEN_CENTRAL_PASSWORD:
+        required: false
+      GPG_KEY_ID:
+        required: false
+      GPG_KEY_PASSWORD:
+        required: false
+      NPM_REPO:
+        required: true
+      DOCS_REPO:
+        required: true
+      DOCS_REPO_EVOLVE_WORKFLOW:
+        required: true
+
+
 
 jobs:
   release-checks:
@@ -46,13 +70,13 @@ jobs:
       NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
       NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
       NEXUS_MAVEN_SNAPSHOT: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +100,7 @@ jobs:
         with:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
-       
+
       - name: Release checks and update version for release
         id: check
         run: |
@@ -85,6 +109,38 @@ jobs:
           version=$(xmlstarlet pyx pom.xml | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/version")
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
+
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
 
       - name: Test changelog format
         id: changelog
@@ -101,9 +157,96 @@ jobs:
           new_changelog=$(echo "${changelog}" | base64 -w0)
           echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
 
+  build-docs:
+    needs: release-checks
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
+    container: node:20-alpine
+    steps:
+      - name: Install Git
+        run: |
+          apk add git zip
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - uses: actions/checkout@v4
+
+      - name: Checkout release branch
+        run: |
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --all
+          git checkout release
+        shell: sh
+
+      - name: Cache nodejs deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          VERSION: ${{ needs.release-checks.outputs.version }}
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: sh
+
+      - uses: actions/upload-artifact@v4
+        if: steps.build.outcome == 'success'
+        with:
+          name: docs.zip
+          path: docs.zip
+          if-no-files-found: error
+
+      - name: Fail build
+        if: steps.build.outcome == 'failure'
+        run: |
+          git push origin -d release
+          echo "There was an error in the docusaurus build above."
+          exit 1
+        shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
 
   deploy:
-    needs: release-checks
+    needs: [release-checks, build-docs]
     runs-on: ubuntu-latest
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
@@ -157,7 +300,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: steps.build.outcome == 'success'
         uses: codecov/codecov-action@v4
-        with:
+        with: 
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
@@ -177,7 +320,7 @@ jobs:
         shell: bash
 
   create-release:
-    needs: [deploy, release-checks]
+    needs: [deploy, build-docs, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -207,7 +350,7 @@ jobs:
         shell: bash
         continue-on-error: true
 
-      - name: Fail if any previous step failed
+      - name: Delete release branch if merge failed and fail
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
@@ -244,6 +387,14 @@ jobs:
             built-artifacts/${{ needs.deploy.outputs.artifact }}
         continue-on-error: true
 
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
+        continue-on-error: true
 
   update-version:
     needs: [create-release]

--- a/.github/workflows/npm-app-old-release.yml
+++ b/.github/workflows/npm-app-old-release.yml
@@ -3,11 +3,6 @@ name: NPM Static App Release
 on:
   workflow_call:
     inputs:
-      product-key:
-        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: false
-        default: "productkeynotprovided"
-        type: string
       private:
         description: 'Calling workflow from a private repo'
         required: false
@@ -35,20 +30,21 @@ on:
     outputs:
       version:
         description: "The current released version."
-        value: ${{ jobs.build-artifact.outputs.version }}
+        value: ${{ jobs.release-checks.outputs.version }}
 jobs:
   release-checks:
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     continue-on-error: false
     env:
+      DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      docs-present: ${{ steps.docs.outputs.present }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,9 +77,21 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
       - name: Check if docs present
         id: docs
-        shell: bash
         run: |
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
@@ -114,35 +122,19 @@ jobs:
               exit 1
           fi
 
-      - name: Test changelog format
-        id: changelog
-        run: |
-          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
-          if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
-            git push origin -d release
-            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
-            exit 1
-          fi
-          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
-          new_changelog=$(echo "${changelog}" | base64 -w0)
-          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
-
   build-docs:
     needs: release-checks
-    runs-on: ubuntu-latest
     if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
+    runs-on: ubuntu-latest
     outputs:
       artifact: docs
-      product-key: ${{ steps.docs-component.outputs.name }}
-      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - name: Install Git
         run: |
-          apk add git zip
+          apk add git tar
 
       - name: Work around git permission issue
         run: |
@@ -176,17 +168,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Zip documentation
-        run: |
-          cd docs/build
-          zip -r ../../docs.zip .
-        shell: sh
-
       - uses: actions/upload-artifact@v4
         if: steps.build.outcome == 'success'
         with:
-          name: docs.zip
-          path: docs.zip
+          name: docs
+          path: docs/build/
           if-no-files-found: error
 
       - name: Fail build
@@ -197,38 +183,13 @@ jobs:
           exit 1
         shell: sh
 
-      - name: Fetch the document component name
-        id: docs-component
-        shell: sh {0}
-        run: |
-            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
-            # if product key is supplied
-            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
-              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
-            else
-              # This is just so we know that we can parse the docs component properly
-              if [ -f docs/docusaurus.config.js ]; then
-                # Parse out the baseUrl from the docusaurus configuration.
-                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
-                # Find the component name
-                doc_comp=${baseurl##*/}
-                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
-              else
-                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
-                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
-                  exit 1
-              fi
-            fi
-
-
   build-artifact:
+    if: ${{ !failure() }}
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
     container: node:20-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
-      artifact-id: ${{ steps.build.outputs.artifact-id }}
-      version: ${{ steps.build.outputs.version }}
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
@@ -272,15 +233,16 @@ jobs:
 
       - name: build
         id: build
+        env:
+          HUSKY: 0
         run: |
+          echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
           npm ci --unsafe-perm
           npm run prod
-          version=$(jq -r .version package.json)
           artifactId=$(jq -r .name package.json)
-          artifact="$artifactId-$version.tar.bz2"
+          artifact="$artifactId-$${{ needs.release-checks.outputs.version }}.tar.bz2"
           tar jcvf "$artifact" -C dist .
-          echo "version=$version" >> "${GITHUB_OUTPUT}"
-          echo "artifact=$artifact" >> "${GITHUB_OUTPUT}"
+          echo "artifact=$artifact" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - uses: actions/upload-artifact@v4
@@ -298,13 +260,15 @@ jobs:
         shell: sh
 
   create-release:
-    needs: [build-artifact]
+    if: ${{ !failure() }}
+    needs: [build-artifact, release-checks]
     runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     outputs:
       artifact: ${{ steps.merge.outputs.artifact }}
       tag: ${{ steps.merge.outputs.tag }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -316,12 +280,18 @@ jobs:
           git config --global --add safe.directory /__w/$dname/$dname
         shell: sh
 
-      - name: Get latest changelog
-        id: changelog
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-artifact.outputs.artifact }}
+          path: built-artifacts/
+        continue-on-error: false
+
+      - name: Check artifact
         run: |
-          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
-        shell: bash
-        continue-on-error: true
+          ls -la
+          ls -la built-artifacts
+        shell: sh
 
       - name: Merge and Tag
         id: merge
@@ -330,11 +300,10 @@ jobs:
           git fetch --all
           git merge origin/release
           git push origin ${GITHUB_REF/refs\/heads\//}
-          version=$(jq -r .version package.json)
-          git tag "v$version"
+          tag="v${{ needs.release-checks.outputs.version }}"
+          git tag $tag
           git push --tags
-          echo "::set-output name=tag::$(echo v$version)"
-          echo "::set-output name=artifact::$(echo ${{ needs.build-artifact.outputs.artifact }})"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
         shell: bash
         continue-on-error: true
 
@@ -345,6 +314,23 @@ jobs:
           echo "There was an error in merging the branch. release branch was deleted."
           exit 1
         shell: bash
+
+      - name: Get latest changelog
+        id: changelog
+        run: |
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
+        shell: bash
+        continue-on-error: true
+
+      - name: Tell user to release themselves
+        if: steps.changelog.outcome == 'failure'
+        run: |
+          echo "There was an error generating a changelog to associate with the release (see previous step and step in release-checks). You'll need to:"
+          echo "1. Fix the changelog"
+          echo "2. Manually create the release"
+          echo "3. Update to the next snapshot version."
+          exit 1
+        shell: sh
 
       - name: Create Release and upload assets
         if: success()
@@ -361,16 +347,16 @@ jobs:
             built-artifacts/${{ needs.build-artifact.outputs.artifact }}
         continue-on-error: true
 
-      - name: Deploy documentation
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          repository: ${{ secrets.DOCS_REPO }}
-          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
-        continue-on-error: true
+      - name: Fail Release
+        if: steps.create_release.outcome == 'failure'
+        run: |
+          git push origin -d release
+          echo "There was an error in the npm package release above."
+          exit 1
+        shell: sh
 
   update-version:
+    if: ${{ !failure() }}
     needs: create-release
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
@@ -392,5 +378,5 @@ jobs:
 
       - name: Update to next minor version
         run: |
-          /scripts/update-version.sh --js --release package.json changelog.md
+          /scripts/update-version.sh --js --release --grow-changelog package.json changelog.md
         shell: bash

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -3,6 +3,11 @@ name: NPM Static App Release
 on:
   workflow_call:
     inputs:
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: false
+        default: "productkeynotprovided"
+        type: string
       private:
         description: 'Calling workflow from a private repo'
         required: false
@@ -37,14 +42,13 @@ jobs:
     container: zepben/pipeline-basic
     continue-on-error: false
     env:
-      DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
       docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,21 +81,9 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Test changelog format
-        id: changelog
-        run: |
-          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
-          if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
-            git push origin -d release
-            exit 1
-          fi
-          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
-          new_changelog=$(echo "${changelog}" | base64 -w0)
-          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
-
       - name: Check if docs present
         id: docs
+        shell: bash
         run: |
           if [ -d docs ]; then
             echo "Docs folder found, will run the build-docs job"
@@ -122,19 +114,35 @@ jobs:
               exit 1
           fi
 
+      - name: Test changelog format
+        id: changelog
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
   build-docs:
     needs: release-checks
-    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     outputs:
       artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
     container: node:20-alpine
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - name: Install Git
         run: |
-          apk add git tar
+          apk add git zip
 
       - name: Work around git permission issue
         run: |
@@ -168,11 +176,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: sh
+
       - uses: actions/upload-artifact@v4
         if: steps.build.outcome == 'success'
         with:
-          name: docs
-          path: docs/build/
+          name: docs.zip
+          path: docs.zip
           if-no-files-found: error
 
       - name: Fail build
@@ -183,13 +197,38 @@ jobs:
           exit 1
         shell: sh
 
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
+
   build-artifact:
-    if: ${{ !failure() }}
     needs: [build-docs, release-checks]
     runs-on: ubuntu-latest
     container: node:20-alpine
     outputs:
       artifact: ${{ steps.build.outputs.artifact }}
+      artifact-id: ${{ steps.build.outputs.artifact-id }}
+      version: ${{ steps.build.outputs.version }}
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
@@ -233,16 +272,15 @@ jobs:
 
       - name: build
         id: build
-        env:
-          HUSKY: 0
         run: |
-          echo "NPM is sensitive to .npmrc formatting; check that it has a newline at the end!!!"
           npm ci --unsafe-perm
           npm run prod
+          version=$(jq -r .version package.json)
           artifactId=$(jq -r .name package.json)
-          artifact="$artifactId-$${{ needs.release-checks.outputs.version }}.tar.bz2"
+          artifact="$artifactId-$version.tar.bz2"
           tar jcvf "$artifact" -C dist .
-          echo "artifact=$artifact" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
+          echo "artifact=$artifact" >> "${GITHUB_OUTPUT}"
         continue-on-error: true
 
       - uses: actions/upload-artifact@v4
@@ -260,15 +298,13 @@ jobs:
         shell: sh
 
   create-release:
-    if: ${{ !failure() }}
-    needs: [build-artifact, release-checks]
+    needs: [build-artifact]
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic
-    env:
-      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     outputs:
       artifact: ${{ steps.merge.outputs.artifact }}
       tag: ${{ steps.merge.outputs.tag }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -311,7 +347,8 @@ jobs:
         if: steps.merge.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in merging the branch. release branch was deleted."
+          echo "There was an error in merging the releae branch. It was deleted, check errors"
+          echo " :boom: There was an error in merging the releae branch. It was deleted, check errors!" >> "${GITHUB_STEP_SUMMARY}"
           exit 1
         shell: bash
 
@@ -355,8 +392,15 @@ jobs:
           exit 1
         shell: sh
 
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
+
   update-version:
-    if: ${{ !failure() }}
     needs: create-release
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic

--- a/.github/workflows/python-lib-old-release.yml
+++ b/.github/workflows/python-lib-old-release.yml
@@ -1,13 +1,8 @@
-# Note: default release notes file is docs/release.md.
-name: Python Library Release + Docs
+name: Python Library Release
 
 on: 
   workflow_call:
     inputs:
-      product-key:
-        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
-        required: false
-        type: string
       private:
         description: 'Calling workflow from a private repo'
         required: false
@@ -36,15 +31,12 @@ on:
         required: false
       COVERALLS_REPO_TOKEN:
         required: false
-      PYPI_API_TOKEN:
+      PYPI_USERNAME:
+        required: false
+      PYPI_PASSWORD:
         required: false
       NPM_REPO:
         required: true
-      DOCS_REPO:
-        required: true
-      DOCS_REPO_EVOLVE_WORKFLOW:
-        required: true
-
 
 
 jobs:
@@ -58,8 +50,6 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
-      docs-present: ${{ steps.docs.outputs.present }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,7 +65,7 @@ jobs:
         id: check
         run: |
           /scripts/release-checks.sh --python setup.py
-          /scripts/finalize-version.sh --python setup.py
+          /scripts/finalize-version.sh --python setup.py changelog.md
           version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
@@ -92,53 +82,6 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
-      - name: Check if docs present
-        id: docs
-        run: |
-          if [ -d docs ]; then
-            echo "Docs folder found, will run the build-docs job"
-            echo "present=yes" >> "${GITHUB_OUTPUT}"
-            echo "present=yes" >> "${GITHUB_ENV}"
-          else
-            echo "Docs folder not found, will skip the build-docs"
-          fi
-
-      - name: Check doc build artifacts are ignored
-        if: ${{ env.present == 'yes' }}
-        shell: sh {0}
-        run: |
-          # Make sure directories are properly ignored
-          # docs/node_modules
-          git check-ignore -q docs/node_modules 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
-              exit 1
-          fi
-
-          # docs/build
-          git check-ignore -q docs/build 
-          if [ $? != 0 ]; then
-              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
-              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
-              exit 1
-          fi
-
-      - name: Test changelog format
-        id: changelog
-        shell: bash
-        run: |
-          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
-          if [[ -z "$changelog" ]]; then
-            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
-            git push origin -d release
-            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
-            exit 1
-          fi
-          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
-          new_changelog=$(echo "${changelog}" | base64 -w0)
-          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
-
   python-deps-check:
     needs: release-checks
     runs-on: ubuntu-latest
@@ -152,99 +95,8 @@ jobs:
           # from zepben packages. Now let's try to install to see if deps exist or fail quick
           pip install --pre '.'
 
-
-  build-docs:
-    needs: [release-checks, python-deps-check]
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
-    outputs:
-      artifact: docs
-      product-key: ${{ steps.docs-component.outputs.name }}
-      product-repo: ${{ steps.docs-component.outputs.repo }}
-    container: node:20-alpine
-    steps:
-      - name: Install Git
-        run: |
-          apk add git zip
-
-      - name: Work around git permission issue
-        run: |
-          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-          git config --global --add safe.directory /__w/$dname/$dname
-        shell: sh
-
-      - uses: actions/checkout@v4
-
-      - name: Checkout release branch
-        run: |
-          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --all
-          git checkout release
-        shell: sh
-
-      - name: Cache nodejs deps
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm
-
-      - name: Build docusaurus
-        id: build
-        uses: zepben/docusaurus-action@main
-        with:
-          VERSION: ${{ needs.release-checks.outputs.version }}
-          NPM_REPO: ${{ secrets.NPM_REPO }}
-          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Zip documentation
-        run: |
-          cd docs/build
-          zip -r ../../docs.zip .
-        shell: sh
-
-      - uses: actions/upload-artifact@v4
-        if: steps.build.outcome == 'success'
-        with:
-          name: docs.zip
-          path: docs.zip
-          if-no-files-found: error
-
-      - name: Fail build
-        if: steps.build.outcome == 'failure'
-        run: |
-          git push origin -d release
-          echo "There was an error in the docusaurus build above."
-          exit 1
-        shell: sh
-
-      - name: Fetch the document component name
-        id: docs-component
-        shell: sh {0}
-        run: |
-            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
-            # if product key is supplied
-            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
-              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
-            else
-              # This is just so we know that we can parse the docs component properly
-              if [ -f docs/docusaurus.config.js ]; then
-                # Parse out the baseUrl from the docusaurus configuration.
-                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
-                # Find the component name
-                doc_comp=${baseurl##*/}
-                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
-              else
-                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
-                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
-                  exit 1
-              fi
-            fi
-
-
-
   deploy:
-    needs: [release-checks, build-docs]
+    needs: [release-checks, python-deps-check]
     runs-on: ubuntu-latest
     container: python:3.9
     outputs:
@@ -296,13 +148,13 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
-          
 
       - uses: actions/upload-artifact@v4
         if: steps.build.outcome == 'success'
         with:
           name: ${{ steps.build.outputs.artifact }}
           path: ${{ steps.build.outputs.artifact-path }}
+          if-no-files-found: error
 
       - name: Delete release branch if deploy failed and fail
         if: steps.build.outcome == 'failure'
@@ -313,7 +165,7 @@ jobs:
         shell: bash
 
   create-release:
-    needs: [deploy, build-docs, release-checks]
+    needs: [deploy, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -358,13 +210,6 @@ jobs:
           path: built-artifacts
         continue-on-error: true
 
-      - name: Get latest changelog
-        id: changelog
-        run: |
-          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
-        shell: bash
-        continue-on-error: true
-
       - name: Create Release and upload assets
         if: success()
         id: create_release
@@ -373,20 +218,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.merge.outputs.tag }}
-          body_path: latest_changelog.txt
+          body_path: changelog.md
           draft: false
           prerelease: false
           files: |
             built-artifacts/${{ needs.deploy.outputs.artifact }}
-        continue-on-error: true
-
-      - name: Deploy documentation
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          repository: ${{ secrets.DOCS_REPO }}
-          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   update-version:
@@ -414,5 +250,5 @@ jobs:
 
       - name: Update to next minor version
         run: |
-          /scripts/update-version.sh --python --release setup.py changelog.md
+          /scripts/update-version.sh --python --grow-changelog --release setup.py changelog.md
         shell: bash

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -1,8 +1,13 @@
-name: Python Library Release
+# Note: default release notes file is docs/release.md.
+name: Python Library Release + Docs
 
 on: 
   workflow_call:
     inputs:
+      product-key:
+        description: 'Product key used for deploying docs. Should be repo specific. E.g: "python-sdk"'
+        required: false
+        type: string
       private:
         description: 'Calling workflow from a private repo'
         required: false
@@ -31,12 +36,15 @@ on:
         required: false
       COVERALLS_REPO_TOKEN:
         required: false
-      PYPI_USERNAME:
-        required: false
-      PYPI_PASSWORD:
+      PYPI_API_TOKEN:
         required: false
       NPM_REPO:
         required: true
+      DOCS_REPO:
+        required: true
+      DOCS_REPO_EVOLVE_WORKFLOW:
+        required: true
+
 
 
 jobs:
@@ -50,6 +58,8 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     outputs:
       version: ${{ steps.check.outputs.version }}
+      docs-present: ${{ steps.docs.outputs.present }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +75,7 @@ jobs:
         id: check
         run: |
           /scripts/release-checks.sh --python setup.py
-          /scripts/finalize-version.sh --python setup.py changelog.md
+          /scripts/finalize-version.sh --python setup.py
           version=$(grep version= setup.py | cut -d= -f2 | tr -d '",')
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         shell: bash
@@ -82,6 +92,53 @@ jobs:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: ${{ inputs.sourcepath }}
 
+      - name: Check if docs present
+        id: docs
+        run: |
+          if [ -d docs ]; then
+            echo "Docs folder found, will run the build-docs job"
+            echo "present=yes" >> "${GITHUB_OUTPUT}"
+            echo "present=yes" >> "${GITHUB_ENV}"
+          else
+            echo "Docs folder not found, will skip the build-docs"
+          fi
+
+      - name: Check doc build artifacts are ignored
+        if: ${{ env.present == 'yes' }}
+        shell: sh {0}
+        run: |
+          # Make sure directories are properly ignored
+          # docs/node_modules
+          git check-ignore -q docs/node_modules 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/node_modules' to .gitignore"
+              exit 1
+          fi
+
+          # docs/build
+          git check-ignore -q docs/build 
+          if [ $? != 0 ]; then
+              echo "ERROR! Make sure to add 'docs/build' to .gitignore"
+              echo "::error line=1::ERROR! Make sure to add 'docs/build' to .gitignore"
+              exit 1
+          fi
+
+      - name: Test changelog format
+        id: changelog
+        shell: bash
+        run: |
+          changelog=$(sed -n -E "/${{ steps.check.outputs.version }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" changelog.md)
+          if [[ -z "$changelog" ]]; then
+            echo "Changelog content was not found - ensure your changelog.md matches the expected growing format. Deleting release branch."
+            git push origin -d release
+            # We can safely fail here because we haven't done anything yet. Changelog.md file should be in correct format.
+            exit 1
+          fi
+          # Changelog has newlines which isn't well supported, so we base64 with line wrap disabled (-w0)
+          new_changelog=$(echo "${changelog}" | base64 -w0)
+          echo "changelog=${new_changelog}" >> $GITHUB_OUTPUT
+
   python-deps-check:
     needs: release-checks
     runs-on: ubuntu-latest
@@ -95,8 +152,99 @@ jobs:
           # from zepben packages. Now let's try to install to see if deps exist or fail quick
           pip install --pre '.'
 
-  deploy:
+
+  build-docs:
     needs: [release-checks, python-deps-check]
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
+    outputs:
+      artifact: docs
+      product-key: ${{ steps.docs-component.outputs.name }}
+      product-repo: ${{ steps.docs-component.outputs.repo }}
+    container: node:20-alpine
+    steps:
+      - name: Install Git
+        run: |
+          apk add git zip
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
+      - uses: actions/checkout@v4
+
+      - name: Checkout release branch
+        run: |
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --all
+          git checkout release
+        shell: sh
+
+      - name: Cache nodejs deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm
+
+      - name: Build docusaurus
+        id: build
+        uses: zepben/docusaurus-action@main
+        with:
+          VERSION: ${{ needs.release-checks.outputs.version }}
+          NPM_REPO: ${{ secrets.NPM_REPO }}
+          NPM_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Zip documentation
+        run: |
+          cd docs/build
+          zip -r ../../docs.zip .
+        shell: sh
+
+      - uses: actions/upload-artifact@v4
+        if: steps.build.outcome == 'success'
+        with:
+          name: docs.zip
+          path: docs.zip
+          if-no-files-found: error
+
+      - name: Fail build
+        if: steps.build.outcome == 'failure'
+        run: |
+          git push origin -d release
+          echo "There was an error in the docusaurus build above."
+          exit 1
+        shell: sh
+
+      - name: Fetch the document component name
+        id: docs-component
+        shell: sh {0}
+        run: |
+            echo "repo=${GITHUB_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+            # if product key is supplied
+            if [ "${{ inputs.product-key }}" != "productkeynotprovided" ]; then
+              echo "name=${{ inputs.product-key }}" >> "${GITHUB_OUTPUT}"
+            else
+              # This is just so we know that we can parse the docs component properly
+              if [ -f docs/docusaurus.config.js ]; then
+                # Parse out the baseUrl from the docusaurus configuration.
+                baseurl=$(grep baseUrl docs/docusaurus.config.js | sed -e "s#/\",##g")
+                # Find the component name
+                doc_comp=${baseurl##*/}
+                echo "name=${doc_comp}" >> "${GITHUB_OUTPUT}"
+              else
+                  echo "Docs folder exists, but there's no docusaurus.config.js; check your code!"
+                  echo " :boom: Docs folder exists, but there's no docusaurus.config.js; check your code!" >> "${GITHUB_STEP_SUMMARY}"
+                  exit 1
+              fi
+            fi
+
+
+
+  deploy:
+    needs: [release-checks, build-docs]
     runs-on: ubuntu-latest
     container: python:3.9
     outputs:
@@ -148,6 +296,7 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
+          
 
       - uses: actions/upload-artifact@v4
         if: steps.build.outcome == 'success'
@@ -165,7 +314,7 @@ jobs:
         shell: bash
 
   create-release:
-    needs: [deploy, release-checks]
+    needs: [deploy, build-docs, release-checks]
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
@@ -210,6 +359,13 @@ jobs:
           path: built-artifacts
         continue-on-error: true
 
+      - name: Get latest changelog
+        id: changelog
+        run: |
+          echo "${{ needs.release-checks.outputs.changelog }}" | base64 -d > latest_changelog.txt
+        shell: bash
+        continue-on-error: true
+
       - name: Create Release and upload assets
         if: success()
         id: create_release
@@ -218,11 +374,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.merge.outputs.tag }}
-          body_path: changelog.md
+          body_path: latest_changelog.txt
           draft: false
           prerelease: false
           files: |
             built-artifacts/${{ needs.deploy.outputs.artifact }}
+        continue-on-error: true
+
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          repository: ${{ secrets.DOCS_REPO }}
+          event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
+          client-payload: '{"product_key": "${{needs.build-docs.outputs.product-key}}", "download_url": "${{needs.build-docs.outputs.product-repo}}"}'
         continue-on-error: true
 
   update-version:


### PR DESCRIPTION
# Description

For quite some time, we've had flows for a release _with_ the documentation and _without_ one. There's no functional difference between the two options, except for the documentation (or, at least, there shouldn't be), and the documentation flows can handle the "no docs" folder situation.

Moreover, we strongly encourage all releases to include their documentation.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

The flows that use "release-with-docs" flows will need to be changed to use "release" without the docs.