### PR TITLE
[OPS-320] gitleaks setup

### DIFF
--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -68,6 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -39,6 +39,39 @@ on:
         required: false
  
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+
   checks:
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -46,8 +46,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -46,6 +46,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -45,32 +45,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
 
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -12,8 +12,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -5,6 +5,39 @@ on:
 
 
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+          
   build-and-test:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java-ewb

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -12,6 +12,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -11,32 +11,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
           
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -34,6 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -56,6 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,32 +33,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -56,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -34,8 +34,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -27,6 +27,39 @@ on:
 
 
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+
   build-and-test:
     runs-on: ubuntu-latest
     container: zepben/pipeline-java-ewb

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -34,6 +34,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -58,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -36,6 +36,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -35,32 +35,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
           
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -29,6 +29,39 @@ on:
         required: false
 
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+          
   build-and-test:
     runs-on: ubuntu-latest
     container: node:20-alpine

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -36,8 +36,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -31,8 +31,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -24,6 +24,39 @@ on:
         required: false
 
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+
   build-and-test:
     runs-on: ubuntu-latest
     container: node:20-alpine

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -53,6 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -30,32 +30,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -31,6 +31,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -18,6 +18,39 @@ on:
         required: false
 
 jobs:
+  check-for-leaks:
+    runs-on: ubuntu-latest
+    container: zepben/pipeline-basic
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: fetch gitleaks config
+          run: |
+            if [ ! -f gitleaks.toml ]; then
+              cp /configs/gitleaks.toml .
+            fi
+          shell: bash
+
+        - uses: gitleaks/gitleaks-action@v2
+          id: leaks
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITLEAKS_CONFIG: gitleaks.toml
+            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          continue-on-error: true
+
+        - name: Comment on pr
+          if: steps.leaks.outcome == 'failure'
+          run: |
+            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+            fi
+
   build-and-test:
     runs-on: ubuntu-latest
     container: python:3.9

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Work around git permission issue
-        run: |
-          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
-          git config --global --add safe.directory /__w/$dname/$dname
-        shell: sh
-
       - name: fetch gitleaks config
         run: |
           if [ ! -f gitleaks.toml ]; then
@@ -49,6 +43,12 @@ jobs:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
           GITLEAKS_VERSION: latest
         continue-on-error: true
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
       - name: Comment on pr
         if: steps.leaks.outcome == 'failure'

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -25,6 +25,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: fetch gitleaks config
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -25,8 +25,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: fetch gitleaks config
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -24,32 +24,38 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-        - name: fetch gitleaks config
-          run: |
-            if [ ! -f gitleaks.toml ]; then
-              cp /configs/gitleaks.toml .
-            fi
-          shell: bash
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
 
-        - uses: gitleaks/gitleaks-action@v2
-          id: leaks
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GITLEAKS_CONFIG: gitleaks.toml
-            GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          continue-on-error: true
+      - name: fetch gitleaks config
+        run: |
+          if [ ! -f gitleaks.toml ]; then
+            cp /configs/gitleaks.toml .
+          fi
+        shell: bash
 
-        - name: Comment on pr
-          if: steps.leaks.outcome == 'failure'
-          run: |
-            if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
-              message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
-              echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
-            fi
+      - uses: gitleaks/gitleaks-action@v2
+        id: leaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+        continue-on-error: true
+
+      - name: Comment on pr
+        if: steps.leaks.outcome == 'failure'
+        run: |
+          if [ "x${{ github.event.pull_request.number }}" != "x" ]; then
+            message="Some secret leaks were potentially detected in this PR.\nCheck https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more info"
+            echo -e "${message}" | gh pr comment ${{ github.event.pull_request.number }} --body-file - 
+          fi
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
-          GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Work around git permission issue

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -47,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
         continue-on-error: true
 
       - name: Comment on pr


### PR DESCRIPTION
# Description

This PR adds the check for secrets leaks to all the `-build` workflows.

If the check finds leaked secrets, it will comment on the code, and an additional PR comment will be made pointing to the action summary. 
PR comments will bug people until the commit with the leak is no longer present in the branch's history. 

## Potential PR spam
This is currently configured with a very low entropy, so it may find many false positives. We might need to update the config if that happens.
 