### PR TITLE
Disable artifact uploading in gitleaks as we're running in a custom container

### DIFF
--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -69,6 +69,7 @@ jobs:
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
           GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/maven-build-oss.yml
+++ b/.github/workflows/maven-build-oss.yml
@@ -35,6 +35,7 @@ jobs:
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
           GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -56,6 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 

--- a/.github/workflows/npm-app-build.yml
+++ b/.github/workflows/npm-app-build.yml
@@ -59,6 +59,7 @@ jobs:
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
           GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/npm-lib-build.yml
+++ b/.github/workflows/npm-lib-build.yml
@@ -54,6 +54,7 @@ jobs:
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
           GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 
       - name: Comment on pr

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -41,6 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: gitleaks.toml
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # Only required for Organizations, not personal accounts.
+          GITLEAKS_VERSION: latest
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
         continue-on-error: true
 


### PR DESCRIPTION
# Description

Disable artefact uploading in Gitleaks, as we're running in a container. When that happens, Gitleaks is unable to detect the artefact directory structure properly, so we skip it altogether - we only actually need the information about the leaks.