### PR TITLE
Fix release flows

### DIFF
--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -375,6 +375,7 @@ jobs:
 
   update-version:
     needs: [create-release]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -396,6 +396,7 @@ jobs:
 
   update-version:
     needs: [create-release]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -400,8 +400,8 @@ jobs:
 
   update-version:
     needs: [create-release]
-    runs-on: ubuntu-latest
     if: always() && !failure() && !cancelled()
+    runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:
       DEBUG: ${{ secrets.DEBUG }}

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -403,6 +403,7 @@ jobs:
 
   update-version:
     needs: create-release
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -254,6 +254,7 @@ jobs:
 
   update-version:
     needs: create-release
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -398,6 +398,7 @@ jobs:
 
   update-version:
     needs: [create-release]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     env:


### PR DESCRIPTION
# Description

The release flow fixes we've previously made are not enough. Even though the `update-version` job doesn't directly depend on docs building, the transitive dependence makes it skip if the `build-docs` is skipped. Therefore, we need to add a fix always to run it if everything else in the job chain is successful.

But also, we should probably redesign this.