### PR TITLE
[OPS-547] Don't allow release and snapshot workflows to run concurrently

### DIFF
--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -61,6 +61,10 @@ on:
         description: "The current released version."
         value: ${{ jobs.release-checks.outputs.version }}
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   release-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -62,6 +62,10 @@ on:
         description: "The current released version."
         value: ${{ jobs.build.outputs.version }}
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-app-release.yml
+++ b/.github/workflows/maven-app-release.yml
@@ -57,6 +57,11 @@ on:
       version:
         description: "The current released version."
         value: ${{ jobs.release-checks.outputs.version }}
+
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   release-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-app-snapshot.yml
+++ b/.github/workflows/maven-app-snapshot.yml
@@ -59,6 +59,11 @@ on:
       version:
         description: "The current released version."
         value: ${{ jobs.build-app.outputs.version }}
+
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   build-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-lib-release.yml
+++ b/.github/workflows/maven-lib-release.yml
@@ -63,7 +63,9 @@ on:
       DOCS_REPO_EVOLVE_WORKFLOW:
         required: true
 
-
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
 
 jobs:
   release-checks:
@@ -251,7 +253,9 @@ jobs:
         if: steps.build.outcome == 'failure'
         run: |
           git push origin -d release
-          echo "There was an error in the mvn deploy command above."
+          echo "##########################################################################"
+          echo "#  There was an error in the mvn deploy command above (Mvn Package Step) #"
+          echo "##########################################################################"
           exit 1
         shell: bash
 

--- a/.github/workflows/maven-lib-snapshot.yml
+++ b/.github/workflows/maven-lib-snapshot.yml
@@ -59,6 +59,10 @@ on:
       LC_URL: 
         required: false
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
 
   check-docs:

--- a/.github/workflows/npm-app-release.yml
+++ b/.github/workflows/npm-app-release.yml
@@ -36,6 +36,11 @@ on:
       version:
         description: "The current released version."
         value: ${{ jobs.release-checks.outputs.version }}
+
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   release-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-app-snapshot-release.yml
+++ b/.github/workflows/npm-app-snapshot-release.yml
@@ -41,6 +41,11 @@ on:
       version:
         description: "The current released version."
         value: ${{ jobs.build-artifact.outputs.version }}
+
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   build-artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-lib-release.yml
+++ b/.github/workflows/npm-lib-release.yml
@@ -27,6 +27,10 @@ on:
       LC_URL:
         required: false
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   release-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-lib-snapshot.yml
+++ b/.github/workflows/npm-lib-snapshot.yml
@@ -37,6 +37,10 @@ on:
       LC_URL:
         required: false
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
   build-artifact:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -46,7 +46,9 @@ on:
       DOCS_REPO_EVOLVE_WORKFLOW:
         required: true
 
-
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
 
 jobs:
   release-checks:

--- a/.github/workflows/python-lib-snapshot.yml
+++ b/.github/workflows/python-lib-snapshot.yml
@@ -34,6 +34,10 @@ on:
       PYPI_PASSWORD:
         required: false
 
+concurrency:
+  group: release-snapshot
+  cancel-in-progress: false
+
 jobs:
 
   run-checks:


### PR DESCRIPTION
# Description

We had a couple of releases fail due to the `snapshot` and the `release` workflows running at the same time and messing with the git tree. This change groups the `snapshot` and `release` workflows into the same concurrency group, which only allows 1 workflow to execute at a time, placing another into a `PENDING` state while waiting for another workflow to finalise. The following is the type of message the _waiting_ workflow (in this case, a release workflow) will get: 

<img width="1424" height="102" alt="image" src="https://github.com/user-attachments/assets/96ad0765-0daa-42d8-9d54-14f9e61825d9" />
 