### PR TITLE
[DEV-8745] Update csharp builds to build multiple configurations and architectures

### DIFF
--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -76,7 +76,7 @@ jobs:
       docs-present: ${{ steps.docs.outputs.present }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ env.GITHUB_TOKEN }}
 
@@ -171,7 +171,7 @@ jobs:
           git config --global --add safe.directory /__w/$dname/$dname
         shell: sh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Checkout release branch
         run: |
@@ -181,10 +181,10 @@ jobs:
         shell: bash
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v4
 
       - name: Setup MSBuild Path
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1.1.1
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload Release
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.release-checks.outputs.artifact_id }}-${{ needs.release-checks.outputs.version }}-${{ matrix.platform }}
           path: ${{ steps.upload_path.outputs.path }}
@@ -250,7 +250,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ env.GITHUB_TOKEN }}
 
@@ -283,7 +283,7 @@ jobs:
         shell: bash
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: built-artifacts
         continue-on-error: true
@@ -338,7 +338,7 @@ jobs:
       SLACK_NOTIFICATION: YES
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ env.GITHUB_TOKEN }}
 

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -208,7 +208,7 @@ jobs:
         id: upload_path
         run: |
           if [[ -z $BINARY_PATH ]]; then
-            echo "path=${{ needs.release-checks.outputs.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
+            echo "path=${{ needs.release-checks.outputs.artifact_id }}/bin/${{ matrix.platform }}/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
           else
             echo "path=$BINARY_PATH" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -31,12 +31,12 @@ on:
         description: 'Configurations'
         required: false
         type: array
-        default: ["Release"]
+        default: '["Release"]'
       platforms:
         description: 'Platforms'
         required: false
         type: array
-        default: ["x64"]
+        default: '["x64"]'
       binary_path:
         description: 'Path to the binaries.'
         required: false
@@ -162,8 +162,8 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        platform: ${{ inputs.platforms }}
-        configuration: ${{ inputs.configurations }}
+        platform: ${{ fromJson(inputs.platforms) }}
+        configuration: ${{ fromJson(inputs.configurations) }}
     steps:
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -30,12 +30,12 @@ on:
       configurations:
         description: 'Configurations'
         required: false
-        type: array
+        type: string
         default: '["Release"]'
       platforms:
         description: 'Platforms'
         required: false
-        type: array
+        type: string
         default: '["x64"]'
       binary_path:
         description: 'Path to the binaries.'

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -27,16 +27,16 @@ on:
         required: false
         type: string
         default: "src"
-      configuration:
-        description: 'Configuration'
+      configurations:
+        description: 'Configurations'
         required: false
-        type: string
-        default: "Release"
-      platform:
-        description: 'Platform'
+        type: array
+        default: ["Release"]
+      platforms:
+        description: 'Platforms'
         required: false
-        type: string
-        default: "x64"
+        type: array
+        default: ["x64"]
       binary_path:
         description: 'Path to the binaries.'
         required: false
@@ -160,6 +160,10 @@ jobs:
   deploy:
     needs: release-checks
     runs-on: windows-2025
+    strategy:
+      matrix:
+        platform: ${{ inputs.platforms }}
+        configuration: ${{ inputs.configurations }}
     steps:
       - name: Work around git permission issue
         run: |
@@ -190,20 +194,21 @@ jobs:
 
       - name: Restore NuGet Packages
         run:
-          msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
+          msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /t:restore
 
       - name: Build
         id: build
-        run: msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }}
+        run: msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
 
       - name: Test
-        run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ inputs.platform }}
+        if: ${{ inputs.test_files != "" }}
+        run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ matrix.platform }}
 
       - name: Set upload path
         id: upload_path
         run: |
           if [[ -z $BINARY_PATH ]]; then
-            echo "path=${{ needs.release-checks.outputs.artifact_id }}/bin/Release/" >> $GITHUB_OUTPUT
+            echo "path=${{ needs.release-checks.outputs.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
           else
             echo "path=$BINARY_PATH" >> $GITHUB_OUTPUT
           fi
@@ -215,7 +220,7 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.release-checks.outputs.artifact_id }}
+          name: ${{ needs.release-checks.outputs.artifact_id }}-${{ matrix.platform }}
           path: ${{ steps.upload_path.outputs.path }}
           if-no-files-found: error
 
@@ -280,9 +285,11 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.release-checks.outputs.artifact_id }}
           path: built-artifacts
         continue-on-error: true
+
+      - name: Clean documents from the released binaries 
+        run: rm -rf built-artifacts/*docs*.zip
 
       - name: Archive Release
         uses: thedoctor0/zip-release@master

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -220,7 +220,7 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.release-checks.outputs.artifact_id }}-${{ matrix.platform }}
+          name: ${{ needs.release-checks.outputs.artifact_id }}-${{ needs.release-checks.outputs.version }}-${{ matrix.platform }}
           path: ${{ steps.upload_path.outputs.path }}
           if-no-files-found: error
 

--- a/.github/workflows/csharp-app-release.yml
+++ b/.github/workflows/csharp-app-release.yml
@@ -87,7 +87,7 @@ jobs:
         shell: sh
 
       - name: Cache licence-check
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /lc
           key: lcc

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -35,12 +35,12 @@ on:
       configurations:
         description: 'Configurations'
         required: false
-        type: array
+        type: string
         default: '["Release"]'
       platforms:
         description: 'Platforms'
         required: false
-        type: array
+        type: string
         default: '["x64"]'
       binary_path:
         description: 'Path to the binaries.'

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -186,7 +186,7 @@ jobs:
       id: upload_path
       run: |
         if [[ -z $BINARY_PATH ]]; then
-          echo "path=${{ steps.update-info-version.outputs.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
+          echo "path=${{ env.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
         else
           echo "path=$BINARY_PATH" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -202,8 +202,8 @@ jobs:
         path: ${{ steps.upload_path.outputs.path }}
 
   build-docs:
-    needs: [build]
-    if: ${{ needs.build-app.outputs.docs-present == 'yes' }}
+    needs: [release-checks, build]
+    if: ${{ needs.release-checks.outputs.docs-present == 'yes' }}
     uses: ./.github/workflows/build-docs.yml
     with:
       DEPLOY: true

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -186,7 +186,7 @@ jobs:
       id: upload_path
       run: |
         if [[ -z $BINARY_PATH ]]; then
-          echo "path=${{ env.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
+          echo "path=${{ env.artifact_id }}/bin/${{ matrix.platform }}/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
         else
           echo "path=$BINARY_PATH" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -198,7 +198,7 @@ jobs:
       id: upload
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.artifact_id }}-${{ env.info_version }}
+        name: ${{ env.artifact_id }}-${{ env.info_version }}-${{ matrix.platform }}
         path: ${{ steps.upload_path.outputs.path }}
 
   build-docs:

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -82,7 +82,7 @@ jobs:
         shell: sh
 
       - name: Cache licence-check
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /lc
           key: lcc

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -32,16 +32,16 @@ on:
         required: false
         default: "productreponotprovided"
         type: string
-      configuration:
-        description: 'Configuration'
+      configurations:
+        description: 'Configurations'
         required: false
-        type: string
-        default: "Release"
-      platform:
-        description: 'Platform'
+        type: array
+        default: ["Release"]
+      platforms:
+        description: 'Platforms'
         required: false
-        type: string
-        default: "x64"
+        type: array
+        default: ["x64"]
       binary_path:
         description: 'Path to the binaries.'
         required: false
@@ -63,7 +63,7 @@ on:
         value: ${{ jobs.build.outputs.version }}
 
 jobs:
-  checks:
+  release-checks:
     runs-on: ubuntu-latest
     container: zepben/pipeline-basic
     outputs: 
@@ -132,6 +132,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.update-info-version.outputs.info_version }}
+    strategy:
+      matrix:
+        platform: ${{ inputs.platforms }}
+        configuration: ${{ inputs.configurations }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -169,20 +173,20 @@ jobs:
 
     - name: Restore NuGet Packages
       run:
-        msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
+        msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /t:restore
 
     - name: Build
-      run: msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }}
+      run: msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
 
     - name: Test
       if: ${{ inputs.test_files != '' }}
-      run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ inputs.platform }}
+      run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ matrix.platform }}
 
     - name: Set upload path
       id: upload_path
       run: |
         if [[ -z $BINARY_PATH ]]; then
-          echo "path=${{ needs.release-checks.outputs.artifact_id }}/bin/Release/" >> $GITHUB_OUTPUT
+          echo "path=${{ steps.update-info-version.outputs.artifact_id }}/bin/${{ matrix.configuration }}" >> $GITHUB_OUTPUT
         else
           echo "path=$BINARY_PATH" >> $GITHUB_OUTPUT
         fi
@@ -195,7 +199,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.artifact_id }}-${{ env.info_version }}
-        path: ${{ env.artifact_id }}/bin/Release/
+        path: ${{ steps.upload_path.outputs.path }}
 
   build-docs:
     needs: [build]

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ env.GITHUB_TOKEN }}
 
@@ -138,7 +138,7 @@ jobs:
         configuration: ${{ fromJson(inputs.configurations) }}
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Work around git permission issue
       run: |
@@ -147,10 +147,10 @@ jobs:
       shell: sh
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v4
 
     - name: Setup MSBuild Path
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v3
 
     - name: Setup VSTest Path
       uses: darenm/Setup-VSTest@v1.1.1
@@ -196,7 +196,7 @@ jobs:
 
     - name: Upload Release
       id: upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.artifact_id }}-${{ env.info_version }}-${{ matrix.platform }}
         path: ${{ steps.upload_path.outputs.path }}

--- a/.github/workflows/csharp-app-snapshot.yml
+++ b/.github/workflows/csharp-app-snapshot.yml
@@ -36,12 +36,12 @@ on:
         description: 'Configurations'
         required: false
         type: array
-        default: ["Release"]
+        default: '["Release"]'
       platforms:
         description: 'Platforms'
         required: false
         type: array
-        default: ["x64"]
+        default: '["x64"]'
       binary_path:
         description: 'Path to the binaries.'
         required: false
@@ -134,8 +134,8 @@ jobs:
       version: ${{ steps.update-info-version.outputs.info_version }}
     strategy:
       matrix:
-        platform: ${{ inputs.platforms }}
-        configuration: ${{ inputs.configurations }}
+        platform: ${{ fromJson(inputs.platforms) }}
+        configuration: ${{ fromJson(inputs.configurations) }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -18,16 +18,16 @@ on:
         required: false
         type: string
         default: "src"
-      configuration:
+      configurations:
         description: 'Configuration'
         required: false
-        type: string
-        default: "Release"
-      platform:
+        type: array
+        default: ["Release"]
+      platforms:
         description: 'Platform'
         required: false
-        type: string
-        default: "x64"
+        type: array
+        default: ["x64"]
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -146,6 +146,10 @@ jobs:
   build-and-test:
     needs: checks
     runs-on: windows-2025
+    strategy:
+      matrix:
+        platform: ${{ inputs.platforms }}
+        configuration: ${{ inputs.configurations }}
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -175,14 +179,14 @@ jobs:
 
     - name: Restore NuGet Packages
       run:   
-        msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }} /t:restore
+        msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /t:restore
 
     - name: Build
-      run: msbuild /p:Configuration=${{ inputs.configuration }} /p:Platform=${{ inputs.platform }}
+      run: msbuild /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
 
     - name: Test
       if: ${{ inputs.test_files != '' }}
-      run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ inputs.platform }}
+      run: vstest.console.exe ${{ inputs.test_files }} /Platform:${{ matrix.platform }}
 
   build-docs:
     needs: [checks]

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -21,12 +21,12 @@ on:
       configurations:
         description: 'Configurations'
         required: false
-        type: array
+        type: string
         default: '["Release"]'
       platforms:
         description: 'Platforms'
         required: false
-        type: array
+        type: string
         default: '["x64"]'
     secrets:
       CI_GITHUB_TOKEN:

--- a/.github/workflows/csharp-build.yml
+++ b/.github/workflows/csharp-build.yml
@@ -19,15 +19,15 @@ on:
         type: string
         default: "src"
       configurations:
-        description: 'Configuration'
+        description: 'Configurations'
         required: false
         type: array
-        default: ["Release"]
+        default: '["Release"]'
       platforms:
-        description: 'Platform'
+        description: 'Platforms'
         required: false
         type: array
-        default: ["x64"]
+        default: '["x64"]'
     secrets:
       CI_GITHUB_TOKEN:
         required: true
@@ -148,8 +148,8 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        platform: ${{ inputs.platforms }}
-        configuration: ${{ inputs.configurations }}
+        platform: ${{ fromJson(inputs.platforms) }}
+        configuration: ${{ fromJson(inputs.configurations) }}
     env:
       DEBUG: ${{ secrets.DEBUG }}
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Our current csharp builds only support building (and snapshots, and releasing) for one specific configuration and one specific platform. This change adds the ability to support a matrix of those (configuration x architecture).

This also updates the versions of the common actions.