### PR TITLE
Dev 9348 helm charts glue

### DIFF
--- a/.github/actions/helm-registry-login/action.yml
+++ b/.github/actions/helm-registry-login/action.yml
@@ -1,0 +1,19 @@
+name: Helm registry login
+description: Log in to ghcr.io for helm and export HELM_REGISTRY_CONFIG for subsequent steps.
+
+inputs:
+  token:
+    description: Token to authenticate with ghcr.io (e.g. CI_GITHUB_TOKEN or github.token)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Helm registry login
+      shell: bash
+      run: |
+        export HELM_REGISTRY_CONFIG="$RUNNER_TEMP/helm-registry-config.json"
+        echo "HELM_REGISTRY_CONFIG=$HELM_REGISTRY_CONFIG" >> "$GITHUB_ENV"
+        echo "${{ inputs.token }}" | helm registry login ghcr.io \
+          -u "${{ github.actor }}" \
+          --password-stdin

--- a/.github/actions/setup-local-k8s/action.yml
+++ b/.github/actions/setup-local-k8s/action.yml
@@ -1,0 +1,48 @@
+name: Setup local-k8s
+description: Checkout, install Python, and install the local-k8s CLI (from zepben/ci-utils) with its tools on PATH.
+
+inputs:
+  ci_utils_ref:
+    description: Git ref of zepben/ci-utils for local-k8s install
+    required: false
+    default: 'main'
+  python-version:
+    description: Python version to install
+    required: false
+    default: '3.14'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache local-k8s tools
+      uses: actions/cache@v6
+      with:
+        path: ~/.local/share/${{ github.event.repository.name }}
+        key: local-k8s-tools-${{ runner.os }}-${{ inputs.ci_utils_ref }}
+
+    - name: Cache pip downloads
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/pip
+        key: local-k8s-pip-${{ runner.os }}-${{ inputs.ci_utils_ref }}
+
+    - name: Install local-k8s
+      shell: bash
+      run: |
+        python -m venv .venv
+        # shellcheck disable=SC1091
+        source .venv/bin/activate
+        pip install "git+https://github.com/zepben/ci-utils.git@${{ inputs.ci_utils_ref }}#subdirectory=local-k8s"
+        local-k8s tools install
+        echo "$(local-k8s tools path)" >> "$GITHUB_PATH"
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-local-k8s/action.yml
+++ b/.github/actions/setup-local-k8s/action.yml
@@ -14,11 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-
     - name: Setup Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/helm-charts-pr.yml
+++ b/.github/workflows/helm-charts-pr.yml
@@ -38,6 +38,11 @@ jobs:
     outputs:
       charts: ${{ steps.detect.outputs.charts }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       - name: Setup local-k8s
         # Relative ./.github/actions resolves to the *caller* workspace (e.g. deployments),
         # not this reusable-workflow repo — must use an absolute org/repo@ref.

--- a/.github/workflows/helm-charts-pr.yml
+++ b/.github/workflows/helm-charts-pr.yml
@@ -1,0 +1,128 @@
+# Reusable PR workflow for Helm charts under helm_dir (default: helm/).
+name: Helm Charts PR
+
+on:
+  workflow_call:
+    inputs:
+      helm_dir:
+        description: Path to the helm directory containing ct.yaml and charts/
+        type: string
+        default: helm
+      ci_utils_ref:
+        description: Git ref of zepben/ci-utils for local-k8s install
+        type: string
+        default: main
+      # TODO: fix this to be more flexible
+      ci_secret_env_var:
+        description: Env var name pointing at the CI secret env-file path (optional)
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_GITHUB_TOKEN:
+        description: >
+          PAT for docker/login and helm registry login on lint/test
+          (cross-repo OCI pulls e.g. helm-commons).
+        required: true
+      # TODO: fix this to be more flexible - goes with comment above
+      CI_SECRET_ENV_FILE:
+        description: Contents of the env-file secret written when ci_secret_env_var is set
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  list-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.detect.outputs.charts }}
+    steps:
+      - name: Setup local-k8s
+        # Relative ./.github/actions resolves to the *caller* workspace (e.g. deployments),
+        # not this reusable-workflow repo — must use an absolute org/repo@ref.
+        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        with:
+          ci_utils_ref: ${{ inputs.ci_utils_ref }}
+
+      - name: List changed charts
+        id: detect
+        run: |
+          charts=$(local-k8s chart list-changed --helm-dir "${{ inputs.helm_dir }}")
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Changed charts: $charts"
+
+  lint:
+    needs: list-changed
+    if: needs.list-changed.outputs.charts != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.list-changed.outputs.charts) }}
+    steps:
+      - name: Setup local-k8s
+        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        with:
+          ci_utils_ref: ${{ inputs.ci_utils_ref }}
+
+      - name: Helm registry login
+        uses: zepben/.github/.github/actions/helm-registry-login@main
+        with:
+          # PAT: GITHUB_TOKEN cannot read private packages from other repos (e.g. helm-commons).
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Lint chart
+        run: |
+          local-k8s chart lint \
+            --helm-dir "${{ inputs.helm_dir }}" \
+            --chart "${{ matrix.chart }}"
+
+  test:
+    needs: list-changed
+    if: needs.list-changed.outputs.charts != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.list-changed.outputs.charts) }}
+    steps:
+      - name: Setup local-k8s
+        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        with:
+          ci_utils_ref: ${{ inputs.ci_utils_ref }}
+
+      - name: Login to GHCR (docker)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Helm registry login
+        uses: zepben/.github/.github/actions/helm-registry-login@main
+        with:
+          # PAT: GITHUB_TOKEN cannot read private packages from other repos (e.g. helm-commons).
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Write CI secret env-file
+        if: inputs.ci_secret_env_var != ''
+        env:
+          CI_SECRET_ENV_FILE: ${{ secrets.CI_SECRET_ENV_FILE }}
+        run: |
+          secret_path="$RUNNER_TEMP/ci-secret.env"
+          printf '%s\n' "$CI_SECRET_ENV_FILE" > "$secret_path"
+          echo "${{ inputs.ci_secret_env_var }}=$secret_path" >> "$GITHUB_ENV"
+
+      - name: Create kind cluster
+        run: |
+          local-k8s cluster create \
+            --kind-config "${{ inputs.helm_dir }}/kind-cluster.yaml" \
+            --components "${{ inputs.helm_dir }}/cluster-components.yaml"
+          echo "KUBECONFIG=/tmp/kind-k8s-conf.yaml" >> "$GITHUB_ENV"
+
+      - name: Test chart
+        run: |
+          local-k8s chart test \
+            --helm-dir "${{ inputs.helm_dir }}" \
+            --chart "${{ matrix.chart }}"

--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -1,0 +1,93 @@
+# Reusable release workflow for Helm charts under helm_dir (default: helm/).
+# Pushes and tags releases. We expect tests etc passed on the PR workflow.
+name: Helm Charts Release
+
+on:
+  workflow_call:
+    inputs:
+      helm_dir:
+        description: Path to the helm directory containing ct.yaml and charts/
+        type: string
+        default: helm
+      ci_utils_ref:
+        description: Git ref of zepben/ci-utils for local-k8s install
+        type: string
+        default: main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  list-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.detect.outputs.charts }}
+    steps:
+      - name: Setup local-k8s
+        # Relative ./.github/actions resolves to the *caller* workspace (e.g. deployments),
+        # not this reusable-workflow repo so must use an absolute org/repo@ref.
+        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        with:
+          ci_utils_ref: ${{ inputs.ci_utils_ref }}
+
+      - name: List changed charts
+        id: detect
+        run: |
+          before="${{ github.event.before }}"
+          if [[ -z "$before" || "$before" =~ ^0+$ ]]; then
+            before=HEAD~1
+          fi
+          charts=$(local-k8s chart list-changed \
+            --helm-dir "${{ inputs.helm_dir }}" \
+            --since "$before")
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Changed charts (since $before): $charts"
+
+  release:
+    needs: list-changed
+    if: needs.list-changed.outputs.charts != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.list-changed.outputs.charts) }}
+    steps:
+      - name: Setup local-k8s
+        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        with:
+          ci_utils_ref: ${{ inputs.ci_utils_ref }}
+
+      - name: Helm registry login
+        uses: zepben/.github/.github/actions/helm-registry-login@main
+        with:
+          token: ${{ github.token }}
+
+      - name: Push chart
+        id: push
+        run: |
+          json=$(local-k8s chart push \
+            --chart "${{ matrix.chart }}" \
+            --registry-config "$HELM_REGISTRY_CONFIG" \
+            --oci-repo "${{ github.repository }}" \
+            --fail-if-exists)
+          echo "$json"
+          name=$(echo "$json" | jq -r .name)
+          version=$(echo "$json" | jq -r .version)
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Tag release commit
+        run: |
+          TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
+          gh release create "$TAG" --generate-notes

--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -53,6 +53,11 @@ jobs:
       matrix:
         chart: ${{ fromJson(needs.list-changed.outputs.charts) }}
     steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - name: Setup local-k8s
         uses: zepben/.github/.github/actions/setup-local-k8s@main
         with:
@@ -80,8 +85,6 @@ jobs:
       - name: Tag release commit
         run: |
           TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$TAG"
           git push origin "$TAG"
 

--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -52,6 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         chart: ${{ fromJson(needs.list-changed.outputs.charts) }}
+    env:
+      GITHUB_TOKEN: ${secret.CI_GITHUB_TOKEN}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -66,7 +68,7 @@ jobs:
       - name: Helm registry login
         uses: zepben/.github/.github/actions/helm-registry-login@main
         with:
-          token: ${{ github.token }}
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push chart
         id: push
@@ -90,7 +92,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
           gh release create "$TAG" --generate-notes


### PR DESCRIPTION
Add our reusable PR workflow. We check if any charts changed, and if
so, we execute lint/test/push steps.

We extract out the common steps into reusable actions to reduce
duplication in the YAML.

The beta steps from helm-commons have been dropped from this PR. We will
revisit this in a later one as it was decided that this flow was not
necessary in the standard path.
