### PR TITLE
Rename local-k8s -> zep-dev

### DIFF
--- a/.github/actions/setup-zep-dev/action.yml
+++ b/.github/actions/setup-zep-dev/action.yml
@@ -1,9 +1,9 @@
-name: Setup local-k8s
-description: Install Python and the local-k8s CLI (from zepben/ci-utils) with its tools on PATH.
+name: Setup zep-dev
+description: Install Python and the zep-dev CLI (from zepben/ci-utils) with its tools on PATH.
 
 inputs:
   ci_utils_ref:
-    description: Git ref of zepben/ci-utils for local-k8s install
+    description: Git ref of zepben/ci-utils for zep-dev install
     required: false
     default: 'main'
   python-version:
@@ -19,25 +19,25 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Cache local-k8s tools
+    - name: Cache zep-dev tools
       uses: actions/cache@v6
       with:
         path: ~/.local/share/${{ github.event.repository.name }}
-        key: local-k8s-tools-${{ runner.os }}-${{ inputs.ci_utils_ref }}
+        key: zep-dev-tools-${{ runner.os }}-${{ inputs.ci_utils_ref }}
 
     - name: Cache pip downloads
       uses: actions/cache@v6
       with:
         path: ~/.cache/pip
-        key: local-k8s-pip-${{ runner.os }}-${{ inputs.ci_utils_ref }}
+        key: zep-dev-pip-${{ runner.os }}-${{ inputs.ci_utils_ref }}
 
-    - name: Install local-k8s
+    - name: Install zep-dev
       shell: bash
       run: |
         python -m venv .venv
         # shellcheck disable=SC1091
         source .venv/bin/activate
-        pip install "git+https://github.com/zepben/ci-utils.git@${{ inputs.ci_utils_ref }}#subdirectory=local-k8s"
-        local-k8s tools install
-        echo "$(local-k8s tools path)" >> "$GITHUB_PATH"
+        pip install "git+https://github.com/zepben/ci-utils.git@${{ inputs.ci_utils_ref }}#subdirectory=zep-dev"
+        zep-dev tools install
+        echo "$(zep-dev tools path)" >> "$GITHUB_PATH"
         echo "$PWD/.venv/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/helm-charts-pr.yml
+++ b/.github/workflows/helm-charts-pr.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: helm
       ci_utils_ref:
-        description: Git ref of zepben/ci-utils for local-k8s install
+        description: Git ref of zepben/ci-utils for zep-dev install
         type: string
         default: main
       # TODO: fix this to be more flexible
@@ -43,17 +43,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup local-k8s
+      - name: Setup zep-dev
         # Relative ./.github/actions resolves to the *caller* workspace (e.g. deployments),
         # not this reusable-workflow repo — must use an absolute org/repo@ref.
-        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
         with:
           ci_utils_ref: ${{ inputs.ci_utils_ref }}
 
       - name: List changed charts
         id: detect
         run: |
-          charts=$(local-k8s chart list-changed --helm-dir "${{ inputs.helm_dir }}")
+          charts=$(zep-dev chart list-changed --helm-dir "${{ inputs.helm_dir }}")
           echo "charts=$charts" >> "$GITHUB_OUTPUT"
           echo "Changed charts: $charts"
 
@@ -69,8 +69,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup local-k8s
-        uses: zepben/.github/.github/actions/setup-local-k8s@main
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
         with:
           ci_utils_ref: ${{ inputs.ci_utils_ref }}
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Lint chart
         run: |
-          local-k8s chart lint \
+          zep-dev chart lint \
             --helm-dir "${{ inputs.helm_dir }}" \
             --chart "${{ matrix.chart }}"
 
@@ -98,8 +98,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup local-k8s
-        uses: zepben/.github/.github/actions/setup-local-k8s@main
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
         with:
           ci_utils_ref: ${{ inputs.ci_utils_ref }}
 
@@ -127,13 +127,13 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          local-k8s cluster create \
+          zep-dev cluster create \
             --kind-config "${{ inputs.helm_dir }}/kind-cluster.yaml" \
             --components "${{ inputs.helm_dir }}/cluster-components.yaml"
           echo "KUBECONFIG=/tmp/kind-k8s-conf.yaml" >> "$GITHUB_ENV"
 
       - name: Test chart
         run: |
-          local-k8s chart test \
+          zep-dev chart test \
             --helm-dir "${{ inputs.helm_dir }}" \
             --chart "${{ matrix.chart }}"

--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: helm
       ci_utils_ref:
-        description: Git ref of zepben/ci-utils for local-k8s install
+        description: Git ref of zepben/ci-utils for zep-dev install
         type: string
         default: main
 
@@ -29,10 +29,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup local-k8s
+      - name: Setup zep-dev
         # Relative ./.github/actions resolves to the *caller* workspace (e.g. deployments),
         # not this reusable-workflow repo so must use an absolute org/repo@ref.
-        uses: zepben/.github/.github/actions/setup-local-k8s@main
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
         with:
           ci_utils_ref: ${{ inputs.ci_utils_ref }}
 
@@ -43,7 +43,7 @@ jobs:
           if [[ -z "$before" || "$before" =~ ^0+$ ]]; then
             before=HEAD~1
           fi
-          charts=$(local-k8s chart list-changed \
+          charts=$(zep-dev chart list-changed \
             --helm-dir "${{ inputs.helm_dir }}" \
             --since "$before")
           echo "charts=$charts" >> "$GITHUB_OUTPUT"
@@ -65,8 +65,8 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Setup local-k8s
-        uses: zepben/.github/.github/actions/setup-local-k8s@main
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
         with:
           ci_utils_ref: ${{ inputs.ci_utils_ref }}
 
@@ -78,7 +78,7 @@ jobs:
       - name: Push chart
         id: push
         run: |
-          json=$(local-k8s chart push \
+          json=$(zep-dev chart push \
             --chart "${{ matrix.chart }}" \
             --registry-config "$HELM_REGISTRY_CONFIG" \
             --oci-repo "${{ github.repository }}" \


### PR DESCRIPTION
Arguably better name.

Rename PR: https://github.com/zepben/ci-utils/pull/69

