### PR TITLE
Don't create release in App repo

### DIFF
--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -95,9 +95,3 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
-          gh release create "$TAG" --generate-notes


### PR DESCRIPTION
This was a bit of a brainfart. We don't want to create releases when we publish charts, that is silly.

