### PR TITLE
Fix Helm release flow

### DIFF
--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -78,20 +78,9 @@ jobs:
       - name: Push chart
         id: push
         run: |
-          json=$(zep-dev chart push \
+          zep-dev chart push \
             --chart "${{ matrix.chart }}" \
             --registry-config "$HELM_REGISTRY_CONFIG" \
             --oci-repo "${{ github.repository }}" \
-            --fail-if-exists)
-          echo "$json"
-          name=$(echo "$json" | jq -r .name)
-          version=$(echo "$json" | jq -r .version)
-          echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Tag release commit
-        run: |
-          TAG="${{ steps.push.outputs.name }}/${{ steps.push.outputs.version }}"
-          git tag "$TAG"
-          git push origin "$TAG"
 


### PR DESCRIPTION
We have removed the --fail-if-exists flag and made the command always idempotent. This is to support upcoming work regarding ad hoc chart and image builds. We also drop the tagging, it is not nececssary. If we later want to add it back, we can do so, but for now it isn't serving any purpose.

