### PR TITLE
Dev 9875 chart release flows

### DIFF
--- a/.github/workflows/build-sealed-docker-image-and-chart.yml
+++ b/.github/workflows/build-sealed-docker-image-and-chart.yml
@@ -1,0 +1,136 @@
+# Reusable application release workflow. Intended as a drop-in
+# replacement for .github/workflows/build-sealed-docker-image.yml
+name: Build Sealed Docker Image and Chart
+
+on:
+  workflow_call:
+    inputs:
+      version_tag:
+        description: Precomputed version tag to use as a Docker image tag
+        type: string
+        default: ''
+      latest_tag:
+        description: If the image should be tagged with 'latest'. Should only be used for release builds
+        type: boolean
+        default: false
+      edge_tag:
+        description: If the image should be tagged with 'edge'. Should only be used for snapshot builds
+        type: boolean
+        default: false
+      push_image:
+        description: If the image should be pushed to GHCR
+        type: boolean
+        default: false
+      dockerfile:
+        description: Override the Dockerfile in use
+        type: string
+        default: 'Dockerfile'
+      build-args:
+        description: Build args for building the Dockerfile
+        required: false
+        type: string
+        default: ''
+      commit:
+        description: Override the commit to build the container and charts from
+        required: false
+        type: string
+        default: ''
+      sha-tags:
+        description: Override if SHA-based image tags should be published
+        required: false
+        type: boolean
+        default: true
+      helm_dir:
+        description: Path to the helm directory containing ct.yaml and charts/
+        type: string
+        default: helm
+    secrets:
+      CI_GITHUB_TOKEN:
+        required: true
+      CI_NPM_TOKEN:
+        required: true
+
+      # Nexus Login
+      NEXUS_USERNAME:
+        required: true
+      NEXUS_PASSWORD:
+        required: true
+      NEXUS_SIGNATURE:
+        required: true
+
+      # Nexus docker CR
+      NEXUS_DOCKER_REPO:
+        required: true
+
+      # Maven
+      NEXUS_MAVEN_REPO:
+        required: true
+      NEXUS_MAVEN_SNAPSHOT:
+        required: true
+      NEXUS_MAVEN_RELEASE:
+        required: true
+
+      # NPM
+      NEXUS_NPM_REPO:
+        required: true
+
+      # Nuget
+      NEXUS_NUGET_FEED:
+        required: true
+
+jobs:
+  image:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-sealed-docker-image.yml
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+      CI_NPM_TOKEN: ${{ secrets.CI_NPM_TOKEN }}
+      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+      NEXUS_SIGNATURE: ${{ secrets.NEXUS_SIGNATURE }}
+      NEXUS_DOCKER_REPO: ${{ secrets.NEXUS_DOCKER_REPO }}
+      NEXUS_MAVEN_REPO: ${{ secrets.NEXUS_MAVEN_REPO }}
+      NEXUS_MAVEN_SNAPSHOT: ${{ secrets.NEXUS_MAVEN_SNAPSHOT }}
+      NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
+      NEXUS_NPM_REPO: ${{ secrets.NEXUS_NPM_REPO }}
+      NEXUS_NUGET_FEED: ${{ secrets.NEXUS_NUGET_FEED }}
+    with:
+      version_tag: ${{ inputs.version_tag }}
+      latest_tag: ${{ inputs.latest_tag }}
+      edge_tag: ${{ inputs.edge_tag }}
+      push_image: ${{ inputs.push_image }}
+      dockerfile: ${{ inputs.dockerfile }}
+      build-args: ${{ inputs.build-args }}
+      commit: ${{ inputs.commit }}
+      sha-tags: ${{ inputs.sha-tags }}
+
+  validate-image:
+    if: ${{ inputs.push_image }}
+    needs: image
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require published image tag
+        env:
+          IMAGE_TAG: ${{ needs.image.outputs.image_tag }}
+        run: |
+          if [[ -z "$IMAGE_TAG" ]]; then
+            echo "::error::Image workflow did not produce an image tag" >&2
+            exit 1
+          fi
+
+  chart:
+    if: ${{ inputs.push_image }}
+    needs: [image, validate-image]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/helm-application-charts-release.yml
+    secrets:
+      CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+    with:
+      commit: ${{ inputs.commit }}
+      image_tag: ${{ needs.image.outputs.image_tag }}
+      helm_dir: ${{ inputs.helm_dir }}

--- a/.github/workflows/build-sealed-docker-image-and-chart.yml
+++ b/.github/workflows/build-sealed-docker-image-and-chart.yml
@@ -78,6 +78,14 @@ on:
       NEXUS_NUGET_FEED:
         required: true
 
+    outputs:
+      image_tag:
+        description: Primary published image tag
+        value: ${{ jobs.image.outputs.image_tag }}
+      commit_sha:
+        description: Exact commit used for the image and charts
+        value: ${{ jobs.image.outputs.commit_sha }}
+
 jobs:
   image:
     permissions:
@@ -112,12 +120,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Require published image tag
+      - name: Require image publication metadata
         env:
           IMAGE_TAG: ${{ needs.image.outputs.image_tag }}
+          COMMIT_SHA: ${{ needs.image.outputs.commit_sha }}
         run: |
           if [[ -z "$IMAGE_TAG" ]]; then
             echo "::error::Image workflow did not produce an image tag" >&2
+            exit 1
+          fi
+
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Image workflow did not produce a full commit SHA" >&2
             exit 1
           fi
 
@@ -131,6 +145,6 @@ jobs:
     secrets:
       CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     with:
-      commit: ${{ inputs.commit }}
+      commit: ${{ needs.image.outputs.commit_sha }}
       image_tag: ${{ needs.image.outputs.image_tag }}
       helm_dir: ${{ inputs.helm_dir }}

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -71,6 +71,11 @@ on:
       NEXUS_NUGET_FEED:
         required: true
 
+    outputs:
+      image_tag:
+        description: Primary image tag (metadata-action priority)
+        value: ${{ jobs.build.outputs.image_tag }}
+
 env:
   REGISTRY_URL: "ghcr.io/${{ github.repository }}"
   NEXUS_REGISTRY_URL: "${{ secrets.NEXUS_DOCKER_REPO }}/${{ github.repository }}"
@@ -81,6 +86,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -75,6 +75,9 @@ on:
       image_tag:
         description: Primary image tag (metadata-action priority)
         value: ${{ jobs.build.outputs.image_tag }}
+      commit_sha:
+        description: Exact commit used as the Docker build context
+        value: ${{ jobs.build.outputs.commit_sha }}
 
 env:
   REGISTRY_URL: "ghcr.io/${{ github.repository }}"
@@ -88,6 +91,7 @@ jobs:
       packages: write
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
+      commit_sha: ${{ steps.sha.outputs.long_ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -176,4 +180,3 @@ jobs:
             npm=/home/runner/.npmrc
             maven=/home/runner/.m2/settings.xml
             nuget=/home/runner/.nuget/NuGet/NuGet.Config
-

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -62,6 +62,8 @@ on:
         required: true
 
       # NPM
+      CI_NPM_TOKEN:
+        required: true
       NEXUS_NPM_REPO:
         required: true
 

--- a/.github/workflows/helm-application-charts-release.yml
+++ b/.github/workflows/helm-application-charts-release.yml
@@ -1,0 +1,113 @@
+# Reusable release workflow for application Helm charts that have explicitly
+# opted in via the zepben.com/publish-with-application-image annotation.
+#
+# The checked-in chart version, appVersion, and image tag are development
+# defaults. At release time, we derive the chart metadata from the checked-out
+# commit and replace image.tag with the image published by the release. These
+# changes are made only in the runner checkout and are never committed.
+#
+# If no charts have opted in, we skip publication and complete successfully.
+name: Helm Application Charts Release
+
+on:
+  workflow_call:
+    inputs:
+      helm_dir:
+        description: Path to the helm directory containing ct.yaml and charts/
+        type: string
+        default: helm
+      commit:
+        description: Git ref containing the charts to publish
+        type: string
+        default: ''
+      image_tag:
+        description: Published image tag to write to selected application chart values.yaml
+        type: string
+        required: true
+    secrets:
+      CI_GITHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: helm-chart-publish-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.charts.outputs.charts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit }}
+
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
+        with:
+          ci_utils_ref: main
+
+      - name: Discover opted-in application charts
+        id: charts
+        env:
+          HELM_DIR: ${{ inputs.helm_dir }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ -z "$IMAGE_TAG" ]]; then
+            echo "::error::image_tag is required" >&2
+            exit 1
+          fi
+
+          charts=$(zep-dev chart list \
+            --helm-dir "$HELM_DIR" \
+            --annotation zepben.com/publish-with-application-image=true \
+            --type application)
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Charts: $charts"
+
+          if [[ "$charts" == "[]" ]]; then
+            echo "No opted-in application charts found; skipping publication"
+          fi
+
+  release:
+    if: ${{ needs.discover.outputs.charts != '[]' }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJSON(needs.discover.outputs.charts) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
+        with:
+          ci_utils_ref: main
+
+      - name: Helm registry login
+        uses: zepben/.github/.github/actions/helm-registry-login@main
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Update and publish chart
+        env:
+          CHART: ${{ matrix.chart }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          OCI_REPO: ${{ github.repository }}
+        run: |
+          zep-dev chart metadata update --chart "$CHART" \
+            --image-tag "$IMAGE_TAG"
+          zep-dev chart push \
+            --chart "$CHART" \
+            --registry-config "$HELM_REGISTRY_CONFIG" \
+            --oci-repo "$OCI_REPO"

--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -1,5 +1,5 @@
 # Reusable release workflow for Helm charts under helm_dir (default: helm/).
-# Pushes and tags releases. We expect tests etc passed on the PR workflow.
+# Pushes releases. We expect tests etc passed on the PR workflow.
 name: Helm Charts Release
 
 on:
@@ -15,8 +15,12 @@ on:
         default: main
 
 permissions:
-  contents: write
+  contents: read
   packages: write
+
+concurrency:
+  group: helm-chart-publish-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   list-changed:
@@ -76,11 +80,8 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push chart
-        id: push
         run: |
           zep-dev chart push \
             --chart "${{ matrix.chart }}" \
             --registry-config "$HELM_REGISTRY_CONFIG" \
-            --oci-repo "${{ github.repository }}" \
-
-
+            --oci-repo "${{ github.repository }}"


### PR DESCRIPTION
Add a composite reusable workflow intended to be a dropin replacement for build-sealed-docker-image.yml in those repo where we have helm charts. See commit messages for details.