### PR TITLE
[DEV-9875] Configure concurrancy and permissions

### DIFF
--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -1,5 +1,5 @@
 # Reusable release workflow for Helm charts under helm_dir (default: helm/).
-# Pushes and tags releases. We expect tests etc passed on the PR workflow.
+# Pushes releases. We expect tests etc passed on the PR workflow.
 name: Helm Charts Release
 
 on:
@@ -15,8 +15,12 @@ on:
         default: main
 
 permissions:
-  contents: write
+  contents: read
   packages: write
+
+concurrency:
+  group: helm-chart-publish-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   list-changed:
@@ -76,11 +80,8 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Push chart
-        id: push
         run: |
           zep-dev chart push \
             --chart "${{ matrix.chart }}" \
             --registry-config "$HELM_REGISTRY_CONFIG" \
-            --oci-repo "${{ github.repository }}" \
-
-
+            --oci-repo "${{ github.repository }}"


### PR DESCRIPTION
[DEV-9875] Configure concurrancy and permissions

When we push packages, idempotency is achieved by getting, then setting
if the package does not already exist. This is inherently racy, so
serialize the workflow to prevent the rare possibility of race
conditions from multiple merges to main in quick succession, concurrent runs, etc.
The other helm publish job will also have this helm-chart-publish-${{ github.repository }}
group, ensuring that overlapping workflow runs for a repo queue and run one at a time.

Signed-off-by: William Coe <william.coe@zepben.com>