### PR TITLE
[DEV-9875] Add Application helm release workflow

### DIFF
--- a/.github/workflows/helm-application-charts-release.yml
+++ b/.github/workflows/helm-application-charts-release.yml
@@ -1,0 +1,113 @@
+# Reusable release workflow for application Helm charts that have explicitly
+# opted in via the zepben.com/publish-with-application-image annotation.
+#
+# The checked-in chart version, appVersion, and image tag are development
+# defaults. At release time, we derive the chart metadata from the checked-out
+# commit and replace image.tag with the image published by the release. These
+# changes are made only in the runner checkout and are never committed.
+#
+# If no charts have opted in, we skip publication and complete successfully.
+name: Helm Application Charts Release
+
+on:
+  workflow_call:
+    inputs:
+      helm_dir:
+        description: Path to the helm directory containing ct.yaml and charts/
+        type: string
+        default: helm
+      commit:
+        description: Git ref containing the charts to publish
+        type: string
+        default: ''
+      image_tag:
+        description: Published image tag to write to selected application chart values.yaml
+        type: string
+        required: true
+    secrets:
+      CI_GITHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: helm-chart-publish-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.charts.outputs.charts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit }}
+
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
+        with:
+          ci_utils_ref: main
+
+      - name: Discover opted-in application charts
+        id: charts
+        env:
+          HELM_DIR: ${{ inputs.helm_dir }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ -z "$IMAGE_TAG" ]]; then
+            echo "::error::image_tag is required" >&2
+            exit 1
+          fi
+
+          charts=$(zep-dev chart list \
+            --helm-dir "$HELM_DIR" \
+            --annotation zepben.com/publish-with-application-image=true \
+            --type application)
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Charts: $charts"
+
+          if [[ "$charts" == "[]" ]]; then
+            echo "No opted-in application charts found; skipping publication"
+          fi
+
+  release:
+    if: ${{ needs.discover.outputs.charts != '[]' }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJSON(needs.discover.outputs.charts) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+
+      - name: Setup zep-dev
+        uses: zepben/.github/.github/actions/setup-zep-dev@main
+        with:
+          ci_utils_ref: main
+
+      - name: Helm registry login
+        uses: zepben/.github/.github/actions/helm-registry-login@main
+        with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Update and publish chart
+        env:
+          CHART: ${{ matrix.chart }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          OCI_REPO: ${{ github.repository }}
+        run: |
+          zep-dev chart metadata update --chart "$CHART" \
+            --image-tag "$IMAGE_TAG"
+          zep-dev chart push \
+            --chart "$CHART" \
+            --registry-config "$HELM_REGISTRY_CONFIG" \
+            --oci-repo "$OCI_REPO"


### PR DESCRIPTION
[DEV-9875] Add Application helm release workflow

Add a workflow of publishing Application helm charts.

This release workflow encodes a couple of meaninful decisions that are worth recording.

With versioning, as per the RFC (https://github.com/zepben/deployments/tree/main/docs/rfcs/0002-argocd-and-helm), we lock appVersion to helm version. That is to say, that for every Application release, we publish a new chart, even it is exactly the same. This is to reduce cognitive load when trying to find the correct chart to deploy X version, and also to just keep things as simple as possible. As such, this workflow does not attempt to locate changed charts, it publishes all that have opted in.

The versions themselves are always incrementing, as based on distance from last released tag. See RFC for more details.

Metadata is updated as part of this process. It is only done locally, and the changes are then thrown away. That means that for the fields that are changed, git is out of sync. This documented behavior and accepted as it simplfies things greatly.

The changed fields are Chart.yaml version and appVersion - as descrbed above. And for the values.yaml, we update the Docker tag with version that was built from the same commit. The intended design is that the Docker build occurs before this workflow is executed, and the tag is passed through.

Of note is the chart selection via zep-dev chart list. This ensures that we only modify/build and push charts that have explicitly opted in. This a guard against affecting any other charts that may exist in the helm/charts dir. The workflow is implemented such that if there are no opted in charts, we just skip that. Meaning it is possible to swap to this workflow before helm charts exist in the Application repository.

Signed-off-by: William Coe <william.coe@zepben.com>