### PR TITLE
[DEV-9875] Tighten contract when building images/charts

### DIFF
--- a/.github/workflows/build-sealed-docker-image-and-chart.yml
+++ b/.github/workflows/build-sealed-docker-image-and-chart.yml
@@ -78,6 +78,14 @@ on:
       NEXUS_NUGET_FEED:
         required: true
 
+    outputs:
+      image_tag:
+        description: Primary published image tag
+        value: ${{ jobs.image.outputs.image_tag }}
+      commit_sha:
+        description: Exact commit used for the image and charts
+        value: ${{ jobs.image.outputs.commit_sha }}
+
 jobs:
   image:
     permissions:
@@ -112,12 +120,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Require published image tag
+      - name: Require image publication metadata
         env:
           IMAGE_TAG: ${{ needs.image.outputs.image_tag }}
+          COMMIT_SHA: ${{ needs.image.outputs.commit_sha }}
         run: |
           if [[ -z "$IMAGE_TAG" ]]; then
             echo "::error::Image workflow did not produce an image tag" >&2
+            exit 1
+          fi
+
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Image workflow did not produce a full commit SHA" >&2
             exit 1
           fi
 
@@ -131,6 +145,6 @@ jobs:
     secrets:
       CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
     with:
-      commit: ${{ inputs.commit }}
+      commit: ${{ needs.image.outputs.commit_sha }}
       image_tag: ${{ needs.image.outputs.image_tag }}
       helm_dir: ${{ inputs.helm_dir }}

--- a/.github/workflows/build-sealed-docker-image.yml
+++ b/.github/workflows/build-sealed-docker-image.yml
@@ -75,6 +75,9 @@ on:
       image_tag:
         description: Primary image tag (metadata-action priority)
         value: ${{ jobs.build.outputs.image_tag }}
+      commit_sha:
+        description: Exact commit used as the Docker build context
+        value: ${{ jobs.build.outputs.commit_sha }}
 
 env:
   REGISTRY_URL: "ghcr.io/${{ github.repository }}"
@@ -88,6 +91,7 @@ jobs:
       packages: write
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
+      commit_sha: ${{ steps.sha.outputs.long_ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -176,4 +180,3 @@ jobs:
             npm=/home/runner/.npmrc
             maven=/home/runner/.m2/settings.xml
             nuget=/home/runner/.nuget/NuGet/NuGet.Config
-


### PR DESCRIPTION
[DEV-9875] Tighten contract when building images/charts

We had previously a slightly looser contract between the various parts of this CI flow. This was due to the fact we could be called with a commit, or a named ref such as a branch name. Due to this, the different parts of the workflow could build off different commits if the branch was progressed during build.

To close this gap, make the image’s resolved SHA authoritative, and output it for later steps to consume. This ensures that we are always building off the exact same git commit that the image build was checked out with.

Signed-off-by: William Coe <william.coe@zepben.com>