### PR TITLE
Support overriding default oci_repo

### DIFF
--- a/.github/workflows/helm-charts-release.yml
+++ b/.github/workflows/helm-charts-release.yml
@@ -9,6 +9,10 @@ on:
         description: Path to the helm directory containing ct.yaml and charts/
         type: string
         default: helm
+      oci_repo:
+        description: OCI repository prefix beneath ghcr.io
+        type: string
+        default: zepben/charts
       ci_utils_ref:
         description: Git ref of zepben/ci-utils for zep-dev install
         type: string
@@ -81,7 +85,7 @@ jobs:
 
       - name: Push chart
         env:
-          OCI_REPO: zepben/charts
+          OCI_REPO: ${{ inputs.oci_repo }}
         run: |
           zep-dev chart push \
             --chart "${{ matrix.chart }}" \


### PR DESCRIPTION
This setting controls at what path the chart is published to. For applications, we want "ghcr.io/zepben/charts/", however some repos would benefit from publishing somewhere else, for example "ghcr.io/zepben/helm-commons/zepben-alloy".

